### PR TITLE
Add mock library as dependency in Dockerfile.dev

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -4,7 +4,7 @@ WORKDIR /tmp/smp/
 
 COPY ./requirements.txt /tmp/smp/requirements.txt
 RUN pip install -r requirements.txt
-RUN pip install pytest
+RUN pip install pytest mock
 
 COPY . /tmp/smp/
 RUN pip install .


### PR DESCRIPTION
Hi!
Don't know, maybe I don't understand something... But it seems that `mock` should be added to development dependencies in Dockerfile.dev, in opposite case tests fail when running it inside docker image built from Dockerfile.dev.