### PR TITLE
Fix type of tp in Accuracy class

### DIFF
--- a/segmentation_models_pytorch/utils/functional.py
+++ b/segmentation_models_pytorch/utils/functional.py
@@ -77,7 +77,7 @@ def accuracy(pr, gt, threshold=0.5, ignore_channels=None):
     pr = _threshold(pr, threshold=threshold)
     pr, gt = _take_channels(pr, gt, ignore_channels=ignore_channels)
 
-    tp = torch.sum(gt == pr)
+    tp = torch.sum(gt == pr, dtype=pr.dtype)
     score = tp / gt.view(-1).shape[0]
     return score
 


### PR DESCRIPTION
When printing a accuracy, only zero are output.
When I checked it, there was a problem with the data type, so I fixed it.

Accuracy -> [[link]](https://github.com/qubvel/segmentation_models.pytorch/blob/6b79c831fa3d8df17a5c4e207ebf304bbf42c094/segmentation_models_pytorch/utils/functional.py#L80)

Ex.
```
>>> aa = torch.zeros((1, 12))
>>> aa[0][4] = 1
>>> aa
tensor([[0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0., 0.]])
>>> bb = torch.zeros((1,12))
>>> bb[0][3]=1
>>> bb
tensor([[0., 0., 0., 1., 0., 0., 0., 0., 0., 0., 0., 0.]])
>>> torch.sum(aa==bb)
tensor(10)
>>> torch.sum(aa==bb) / aa.view(-1).shape[0]
tensor(0)
>>> torch.sum(aa==bb, dtype=aa.dtype) / aa.view(-1).shape[0]
tensor(0.8333)
```