### PR TITLE
Fix make dilated

### DIFF
--- a/segmentation_models_pytorch/encoders/_base.py
+++ b/segmentation_models_pytorch/encoders/_base.py
@@ -33,9 +33,5 @@ class EncoderMixin:
         raise NotImplementedError
 
     def make_dilated(self, stage_list, dilation_list):
-        stages = self.get_stages()
-        for stage_indx, dilation_rate in zip(stage_list, dilation_list):
-            utils.replace_strides_with_dilation(
-                module=stages[stage_indx],
-                dilation_rate=dilation_rate,
-            )
+        """Method should be overridden in encoder"""
+        raise NotImplementedError

--- a/segmentation_models_pytorch/encoders/_utils.py
+++ b/segmentation_models_pytorch/encoders/_utils.py
@@ -43,7 +43,7 @@ def replace_strides_with_dilation(module, dilation_rate):
             mod.stride = (1, 1)
             mod.dilation = (dilation_rate, dilation_rate)
             kh, kw = mod.kernel_size
-            mod.padding = ((kh // 2) * dilation_rate, (kh // 2) * dilation_rate)
+            mod.padding = ((kh // 2) * dilation_rate, (kw // 2) * dilation_rate)
 
             # Kostyl for EfficientNet
             if hasattr(mod, "static_padding"):

--- a/segmentation_models_pytorch/encoders/_utils.py
+++ b/segmentation_models_pytorch/encoders/_utils.py
@@ -36,15 +36,12 @@ def patch_first_conv(model, in_channels):
         module.reset_parameters()
 
 
-def replace_strides_with_dilation(module, dilation_rate):
-    """Patch Conv2d modules replacing strides with dilation"""
-    for mod in module.modules():
-        if isinstance(mod, nn.Conv2d):
-            mod.stride = (1, 1)
-            mod.dilation = (dilation_rate, dilation_rate)
-            kh, kw = mod.kernel_size
-            mod.padding = ((kh // 2) * dilation_rate, (kw // 2) * dilation_rate)
-
-            # Kostyl for EfficientNet
-            if hasattr(mod, "static_padding"):
-                mod.static_padding = nn.Identity()
+def to_tuple(sequence_or_value):
+    if isinstance(sequence_or_value, int):
+        return (sequence_or_value, sequence_or_value)
+    elif isinstance(sequence_or_value, list):
+        return tuple(sequence_or_value)
+    elif isinstance(sequence_or_value, tuple):
+        return sequence_or_value
+    else:
+        raise NotImplementedError

--- a/segmentation_models_pytorch/encoders/dpn.py
+++ b/segmentation_models_pytorch/encoders/dpn.py
@@ -73,7 +73,9 @@ class DPNEncorder(DPN, EncoderMixin):
         state_dict.pop("last_linear.weight")
         super().load_state_dict(state_dict, **kwargs)
 
-    def make_dilated(self, stage_list, dilation_list):
+    def make_dilated(self, stage_list, dilation_list=None):
+        if dilation_list is None:
+            dilation_list = map(lambda x: 2**(x+1), range(len(stage_list)))
         stages = self.get_stages()
         dilation = 1
         for stage_indx, stage_dilation in zip(stage_list, dilation_list):

--- a/segmentation_models_pytorch/encoders/efficientnet.py
+++ b/segmentation_models_pytorch/encoders/efficientnet.py
@@ -91,11 +91,13 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
                 if isinstance(mod, nn.Conv2d):
                     kh, kw = utils.to_tuple(mod.kernel_size)
 
-                    if dilation > 1 and not utils.to_tuple(mod.kernel_size) == (1, 1):
-                        mod.dilation = (dilation, dilation)
+                    if not utils.to_tuple(mod.kernel_size) == (1, 1):
                         mod.padding = ((kh // 2) * dilation, (kw // 2) * dilation)
                         if hasattr(mod, "static_padding"):
                             mod.static_padding = nn.Identity()
+
+                        if dilation > 1:
+                            mod.dilation = (dilation, dilation)
 
                     if utils.to_tuple(mod.stride) == (2, 2):
                        mod.stride = (1, 1)

--- a/segmentation_models_pytorch/encoders/efficientnet.py
+++ b/segmentation_models_pytorch/encoders/efficientnet.py
@@ -82,7 +82,9 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
         state_dict.pop("_fc.weight")
         super().load_state_dict(state_dict, **kwargs)
 
-    def make_dilated(self, stage_list, dilation_list):
+    def make_dilated(self, stage_list, dilation_list=None):
+        if dilation_list is None:
+            dilation_list = map(lambda x: 2**(x+1), range(len(stage_list)))
         stages = self.get_stages()
         dilation = 1
         for stage_indx, stage_dilation in zip(stage_list, dilation_list):

--- a/segmentation_models_pytorch/encoders/mobilenet.py
+++ b/segmentation_models_pytorch/encoders/mobilenet.py
@@ -64,7 +64,9 @@ class MobileNetV2Encoder(torchvision.models.MobileNetV2, EncoderMixin):
         state_dict.pop("classifier.1.weight")
         super().load_state_dict(state_dict, **kwargs)
 
-    def make_dilated(self, stage_list, dilation_list):
+    def make_dilated(self, stage_list, dilation_list=None):
+        if dilation_list is None:
+            dilation_list = map(lambda x: 2**(x+1), range(len(stage_list)))
         stages = self.get_stages()
         dilation = 1
         for stage_indx, stage_dilation in zip(stage_list, dilation_list):

--- a/segmentation_models_pytorch/encoders/resnet.py
+++ b/segmentation_models_pytorch/encoders/resnet.py
@@ -31,6 +31,7 @@ from torchvision.models.resnet import Bottleneck
 from pretrainedmodels.models.torchvision_models import pretrained_settings
 
 from ._base import EncoderMixin
+from . import _utils as utils
 
 
 class ResNetEncoder(ResNet, EncoderMixin):
@@ -67,6 +68,27 @@ class ResNetEncoder(ResNet, EncoderMixin):
         state_dict.pop("fc.bias")
         state_dict.pop("fc.weight")
         super().load_state_dict(state_dict, **kwargs)
+
+    def make_dilated(self, stage_list, dilation_list):
+        stages = self.get_stages()
+        dilation = 1
+        for stage_indx, stage_dilation in zip(stage_list, dilation_list):
+            # Patch Conv2d modules replacing strides with dilation
+            for residual_unit in stages[stage_indx].children():
+                for mod in residual_unit.children():
+                    if isinstance(mod, nn.Sequential):  # residue with downsample path
+                        mod[0].stride = (1, 1)
+                        # kernel_size is (1, 1)
+                    elif isinstance(mod, nn.Conv2d):
+                        kh, kw = utils.to_tuple(mod.kernel_size)
+
+                        if dilation > 1 and not utils.to_tuple(mod.kernel_size) == (1, 1):
+                            mod.dilation = (dilation, dilation)
+                            mod.padding = ((kh // 2) * dilation, (kw // 2) * dilation)
+
+                        if utils.to_tuple(mod.stride) == (2, 2):
+                            mod.stride = (1, 1)
+                            dilation = stage_dilation  # for subsequent layers
 
 
 resnet_encoders = {

--- a/segmentation_models_pytorch/encoders/resnet.py
+++ b/segmentation_models_pytorch/encoders/resnet.py
@@ -69,7 +69,9 @@ class ResNetEncoder(ResNet, EncoderMixin):
         state_dict.pop("fc.weight")
         super().load_state_dict(state_dict, **kwargs)
 
-    def make_dilated(self, stage_list, dilation_list):
+    def make_dilated(self, stage_list, dilation_list=None):
+        if dilation_list is None:
+            dilation_list = map(lambda x: 2**(x+1), range(len(stage_list)))
         stages = self.get_stages()
         dilation = 1
         for stage_indx, stage_dilation in zip(stage_list, dilation_list):

--- a/segmentation_models_pytorch/encoders/senet.py
+++ b/segmentation_models_pytorch/encoders/senet.py
@@ -72,7 +72,9 @@ class SENetEncoder(SENet, EncoderMixin):
         state_dict.pop("last_linear.weight")
         super().load_state_dict(state_dict, **kwargs)
 
-    def make_dilated(self, stage_list, dilation_list):
+    def make_dilated(self, stage_list, dilation_list=None):
+        if dilation_list is None:
+            dilation_list = map(lambda x: 2**(x+1), range(len(stage_list)))
         stages = self.get_stages()
         dilation = 1
         for stage_indx, stage_dilation in zip(stage_list, dilation_list):

--- a/segmentation_models_pytorch/encoders/timm_efficientnet.py
+++ b/segmentation_models_pytorch/encoders/timm_efficientnet.py
@@ -5,7 +5,7 @@ from timm.models.efficientnet import EfficientNet, Swish
 from timm.models.efficientnet import decode_arch_def, round_channels, default_cfgs
 
 from ._base import EncoderMixin
-
+from . import _utils as utils
 
 def get_efficientnet_kwargs(channel_multiplier=1.0, depth_multiplier=1.0):
     """Creates an EfficientNet model.
@@ -86,6 +86,27 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
         state_dict.pop("classifier.bias")
         state_dict.pop("classifier.weight")
         super().load_state_dict(state_dict, **kwargs)
+
+    def make_dilated(self, stage_list, dilation_list):
+        stages = self.get_stages()
+        dilation = 1
+        for stage_indx, stage_dilation in zip(stage_list, dilation_list):
+            # Patch Conv2d modules replacing strides with dilation
+            for mod in stages[stage_indx].modules():
+                if isinstance(mod, nn.Conv2d):
+                    kh, kw = utils.to_tuple(mod.kernel_size)
+
+                    if not utils.to_tuple(mod.kernel_size) == (1, 1):
+                        mod.padding = ((kh // 2) * dilation, (kw // 2) * dilation)
+                        if hasattr(mod, "static_padding"):
+                            mod.static_padding = nn.Identity()
+
+                        if dilation > 1:
+                            mod.dilation = (dilation, dilation)
+
+                    if utils.to_tuple(mod.stride) == (2, 2):
+                       mod.stride = (1, 1)
+                       dilation = stage_dilation  # for subsequent layers
 
 
 def prepare_settings(settings):

--- a/segmentation_models_pytorch/encoders/timm_efficientnet.py
+++ b/segmentation_models_pytorch/encoders/timm_efficientnet.py
@@ -87,7 +87,9 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
         state_dict.pop("classifier.weight")
         super().load_state_dict(state_dict, **kwargs)
 
-    def make_dilated(self, stage_list, dilation_list):
+    def make_dilated(self, stage_list, dilation_list=None):
+        if dilation_list is None:
+            dilation_list = map(lambda x: 2**(x+1), range(len(stage_list)))
         stages = self.get_stages()
         dilation = 1
         for stage_indx, stage_dilation in zip(stage_list, dilation_list):


### PR DESCRIPTION
Hello @qubvel

I make this pull request to fix the issue #183. **Let me remind that this issue only affects `DeepLabV3` and `PAN` which indeed calls `self.encoder.make_dilated`**.

I found out that the issue should have even more impact on dilated `efficientnet` because the strided convolution is in the second `MBConvBlock` of the stage and the `dilation` should be applied only on the *subsequent* layers of the strided convolution. The `dilation` ends up being badly applied on the first two `MBConvBlock` of each dilated stage.

As I explained in the issue, I was not able to code a `make_dilated` method in `EncoderMixin` that would have been common to all encoders. Instead, I implemented a `make_dilated` method for all the encoders where is it was not disabled i.e. `resnet`, `senet`, `dpn`, `mobilenet`, `efficientnet`. Then I manually checked that the dilation rate was properly applied to the layers using a `diff` tool. Let me know if you think I should implement some tests.

Compared to `replace_strides_with_dilation`, I purposely do not apply `dilation` (and hence do not modify the `padding`) when the `dilation` is 1 and when the `kernel_size` is (1, 1), because it is useless.

As you proposed, it would be interesting to make a performance comparison before and after this patch for the two use cases discussed in the issue:
1. The encoder is fine-tuned i.e. its pretrained weights are just used as initialization.
2. The encoder is frozen i.e. its weights pretrained on ImageNet are not fine-tuned. The cleanest way would be to use `catalyst.utils.process_model_params` to freeze the `Conv2d`, without forgetting to set the encoder's `BatchNorm` in `eval` mode.

I don't expect the patch to affect a lot the model accuracy in use case 1 because the weights would likely adapt. However, I expect the impact to be non-negligible in use case 2.