### PR TITLE
Add torch hub support

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,6 +1,6 @@
 dependencies = [
     'torch', 'torchvision', 'pretrainedmodels',
-    'efficientnet-pytorch', 'timm'
+    'efficientnet_pytorch', 'timm'
 ]
 
 

--- a/hubconf.py
+++ b/hubconf.py
@@ -4,9 +4,9 @@ dependencies = [
 ]
 
 
-from .unet import Unet
-from .linknet import Linknet
-from .fpn import FPN
-from .pspnet import PSPNet
-from .deeplabv3 import DeepLabV3, DeepLabV3Plus
-from .pan import PAN
+from segmentation_models_pytorch.unet import Unet
+from segmentation_models_pytorch.linknet import Linknet
+from segmentation_models_pytorch.fpn import FPN
+from segmentation_models_pytorch.pspnet import PSPNet
+from segmentation_models_pytorch.deeplabv3 import DeepLabV3, DeepLabV3Plus
+from segmentation_models_pytorch.pan import PAN

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,12 @@
+dependencies = [
+    'torch', 'torchvision', 'pretrainedmodels',
+    'efficientnet-pytorch', 'timm'
+]
+
+
+from .unet import Unet
+from .linknet import Linknet
+from .fpn import FPN
+from .pspnet import PSPNet
+from .deeplabv3 import DeepLabV3, DeepLabV3Plus
+from .pan import PAN


### PR DESCRIPTION
Torch hub is simple protocol to share models: https://pytorch.org/docs/stable/hub.html

After merging of the PR, anyone can do
torch.hub.load('qubvel/segmentation_models.pytorch', 'UNet', encoder_name='resnet18') to load a model.