### PR TITLE
Fixing GPU memory issues on forward pass

### DIFF
--- a/segmentation_models_pytorch/encoders/densenet.py
+++ b/segmentation_models_pytorch/encoders/densenet.py
@@ -58,16 +58,18 @@ class DenseNetEncoder(DenseNet, EncoderMixin):
         raise ValueError("DenseNet encoders do not support dilated mode "
                          "due to pooling operation for downsampling!")
 
-    def get_stages(self):
-        return [
-            nn.Identity(),
-            nn.Sequential(self.features.conv0, self.features.norm0, self.features.relu0),
-            nn.Sequential(self.features.pool0, self.features.denseblock1,
-                          TransitionWithSkip(self.features.transition1)),
-            nn.Sequential(self.features.denseblock2, TransitionWithSkip(self.features.transition2)),
-            nn.Sequential(self.features.denseblock3, TransitionWithSkip(self.features.transition3)),
-            nn.Sequential(self.features.denseblock4, self.features.norm5)
-        ]
+    def get_stages(self): 
+        if not hasattr(self, "stages"):  
+            self.stages =  [
+                nn.Identity(),
+                nn.Sequential(self.features.conv0, self.features.norm0, self.features.relu0),
+                nn.Sequential(self.features.pool0, self.features.denseblock1,
+                              TransitionWithSkip(self.features.transition1)),
+                nn.Sequential(self.features.denseblock2, TransitionWithSkip(self.features.transition2)),
+                nn.Sequential(self.features.denseblock3, TransitionWithSkip(self.features.transition3)),
+                nn.Sequential(self.features.denseblock4, self.features.norm5)
+            ]
+        return self.stages
 
     def forward(self, x):
 

--- a/segmentation_models_pytorch/encoders/dpn.py
+++ b/segmentation_models_pytorch/encoders/dpn.py
@@ -44,14 +44,16 @@ class DPNEncorder(DPN, EncoderMixin):
         del self.last_linear
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            nn.Sequential(self.features[0].conv, self.features[0].bn, self.features[0].act),
-            nn.Sequential(self.features[0].pool, self.features[1 : self._stage_idxs[0]]),
-            self.features[self._stage_idxs[0] : self._stage_idxs[1]],
-            self.features[self._stage_idxs[1] : self._stage_idxs[2]],
-            self.features[self._stage_idxs[2] : self._stage_idxs[3]],
-        ]
+        if not hasattr(self, "stages"):  
+            self.stages =  [
+                nn.Identity(),
+                nn.Sequential(self.features[0].conv, self.features[0].bn, self.features[0].act),
+                nn.Sequential(self.features[0].pool, self.features[1 : self._stage_idxs[0]]),
+                self.features[self._stage_idxs[0] : self._stage_idxs[1]],
+                self.features[self._stage_idxs[1] : self._stage_idxs[2]],
+                self.features[self._stage_idxs[2] : self._stage_idxs[3]],
+            ]
+        return self.stages
 
     def forward(self, x):
 

--- a/segmentation_models_pytorch/encoders/efficientnet.py
+++ b/segmentation_models_pytorch/encoders/efficientnet.py
@@ -43,14 +43,16 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
         del self._fc
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            nn.Sequential(self._conv_stem, self._bn0, self._swish),
-            self._blocks[:self._stage_idxs[0]],
-            self._blocks[self._stage_idxs[0]:self._stage_idxs[1]],
-            self._blocks[self._stage_idxs[1]:self._stage_idxs[2]],
-            self._blocks[self._stage_idxs[2]:],
-        ]
+        if not hasattr(self, "stages"):  
+            self.stages =  [
+                nn.Identity(),
+                nn.Sequential(self._conv_stem, self._bn0, self._swish),
+                self._blocks[:self._stage_idxs[0]],
+                self._blocks[self._stage_idxs[0]:self._stage_idxs[1]],
+                self._blocks[self._stage_idxs[1]:self._stage_idxs[2]],
+                self._blocks[self._stage_idxs[2]:],
+            ]
+        return self.stages
 
     def forward(self, x):
         stages = self.get_stages()

--- a/segmentation_models_pytorch/encoders/inceptionresnetv2.py
+++ b/segmentation_models_pytorch/encoders/inceptionresnetv2.py
@@ -55,14 +55,16 @@ class InceptionResNetV2Encoder(InceptionResNetV2, EncoderMixin):
                          "due to pooling operation for downsampling!")
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            nn.Sequential(self.conv2d_1a, self.conv2d_2a, self.conv2d_2b),
-            nn.Sequential(self.maxpool_3a, self.conv2d_3b, self.conv2d_4a),
-            nn.Sequential(self.maxpool_5a, self.mixed_5b, self.repeat),
-            nn.Sequential(self.mixed_6a, self.repeat_1),
-            nn.Sequential(self.mixed_7a, self.repeat_2, self.block8, self.conv2d_7b),
-        ]
+        if not hasattr(self, "stages"):  
+            self.stages =  [
+                nn.Identity(),
+                nn.Sequential(self.conv2d_1a, self.conv2d_2a, self.conv2d_2b),
+                nn.Sequential(self.maxpool_3a, self.conv2d_3b, self.conv2d_4a),
+                nn.Sequential(self.maxpool_5a, self.mixed_5b, self.repeat),
+                nn.Sequential(self.mixed_6a, self.repeat_1),
+                nn.Sequential(self.mixed_7a, self.repeat_2, self.block8, self.conv2d_7b),
+            ]
+        return self.stages
 
     def forward(self, x):
 

--- a/segmentation_models_pytorch/encoders/inceptionv4.py
+++ b/segmentation_models_pytorch/encoders/inceptionv4.py
@@ -54,14 +54,16 @@ class InceptionV4Encoder(InceptionV4, EncoderMixin):
                          "due to pooling operation for downsampling!")
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            self.features[: self._stage_idxs[0]],
-            self.features[self._stage_idxs[0]: self._stage_idxs[1]],
-            self.features[self._stage_idxs[1]: self._stage_idxs[2]],
-            self.features[self._stage_idxs[2]: self._stage_idxs[3]],
-            self.features[self._stage_idxs[3]:],
-        ]
+        if not hasattr(self, "stages"):  
+            self.stages =  [
+                nn.Identity(),
+                self.features[: self._stage_idxs[0]],
+                self.features[self._stage_idxs[0]: self._stage_idxs[1]],
+                self.features[self._stage_idxs[1]: self._stage_idxs[2]],
+                self.features[self._stage_idxs[2]: self._stage_idxs[3]],
+                self.features[self._stage_idxs[3]:],
+            ]
+        return self.stages
 
     def forward(self, x):
 

--- a/segmentation_models_pytorch/encoders/mobilenet.py
+++ b/segmentation_models_pytorch/encoders/mobilenet.py
@@ -39,14 +39,16 @@ class MobileNetV2Encoder(torchvision.models.MobileNetV2, EncoderMixin):
         del self.classifier
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            self.features[:2],
-            self.features[2:4],
-            self.features[4:7],
-            self.features[7:14],
-            self.features[14:],
-        ]
+        if not hasattr(self, "stages"):  
+            self.stages =  [
+                nn.Identity(),
+                self.features[:2],
+                self.features[2:4],
+                self.features[4:7],
+                self.features[7:14],
+                self.features[14:],
+            ]
+        return self.stages
 
     def forward(self, x):
         stages = self.get_stages()

--- a/segmentation_models_pytorch/encoders/resnet.py
+++ b/segmentation_models_pytorch/encoders/resnet.py
@@ -53,8 +53,7 @@ class ResNetEncoder(ResNet, EncoderMixin):
         ]
         
     def get_stages(self):
-        if not hasattr(self, "stages"): 
-            print("creating stages ...")
+        if not hasattr(self, "stages"):  
             self.stages = [
                 nn.Identity(),
                 nn.Sequential(self.conv1, self.bn1, self.relu),

--- a/segmentation_models_pytorch/encoders/resnet.py
+++ b/segmentation_models_pytorch/encoders/resnet.py
@@ -43,8 +43,7 @@ class ResNetEncoder(ResNet, EncoderMixin):
         del self.fc
         del self.avgpool
 
-    def get_stages(self):
-        return [
+        self.stages = [
             nn.Identity(),
             nn.Sequential(self.conv1, self.bn1, self.relu),
             nn.Sequential(self.maxpool, self.layer1),
@@ -52,7 +51,20 @@ class ResNetEncoder(ResNet, EncoderMixin):
             self.layer3,
             self.layer4,
         ]
-
+        
+    def get_stages(self):
+        if not hasattr(self, "stages"): 
+            print("creating stages ...")
+            self.stages = [
+                nn.Identity(),
+                nn.Sequential(self.conv1, self.bn1, self.relu),
+                nn.Sequential(self.maxpool, self.layer1),
+                self.layer2,
+                self.layer3,
+                self.layer4,
+            ]
+        return self.stages 
+    
     def forward(self, x):
         stages = self.get_stages()
 

--- a/segmentation_models_pytorch/encoders/senet.py
+++ b/segmentation_models_pytorch/encoders/senet.py
@@ -47,14 +47,16 @@ class SENetEncoder(SENet, EncoderMixin):
         del self.avg_pool
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            self.layer0[:-1],
-            nn.Sequential(self.layer0[-1], self.layer1),
-            self.layer2,
-            self.layer3,
-            self.layer4,
-        ]
+        if not hasattr(self, "stages"):  
+            self.stages =  [ 
+                nn.Identity(),
+                self.layer0[:-1],
+                nn.Sequential(self.layer0[-1], self.layer1),
+                self.layer2,
+                self.layer3,
+                self.layer4,
+            ]
+        return self.stages
 
     def forward(self, x):
         stages = self.get_stages()

--- a/segmentation_models_pytorch/encoders/timm_efficientnet.py
+++ b/segmentation_models_pytorch/encoders/timm_efficientnet.py
@@ -63,14 +63,16 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
             del self.classifier
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            nn.Sequential(self.conv_stem, self.bn1, self.act1),
-            self.blocks[:self._stage_idxs[0]],
-            self.blocks[self._stage_idxs[0]:self._stage_idxs[1]],
-            self.blocks[self._stage_idxs[1]:self._stage_idxs[2]],
-            self.blocks[self._stage_idxs[2]:],
-        ]
+        if not hasattr(self, "stages"):  
+            self.stages =  [
+                nn.Identity(),
+                nn.Sequential(self.conv_stem, self.bn1, self.act1),
+                self.blocks[:self._stage_idxs[0]],
+                self.blocks[self._stage_idxs[0]:self._stage_idxs[1]],
+                self.blocks[self._stage_idxs[1]:self._stage_idxs[2]],
+                self.blocks[self._stage_idxs[2]:],
+            ]
+        return self.stages
 
     def forward(self, x):
         stages = self.get_stages()

--- a/segmentation_models_pytorch/encoders/vgg.py
+++ b/segmentation_models_pytorch/encoders/vgg.py
@@ -53,15 +53,16 @@ class VGGEncoder(VGG, EncoderMixin):
                          " operations for downsampling!")
 
     def get_stages(self):
-        stages = []
-        stage_modules = []
-        for module in self.features:
-            if isinstance(module, nn.MaxPool2d):
-                stages.append(nn.Sequential(*stage_modules))
-                stage_modules = []
-            stage_modules.append(module)
-        stages.append(nn.Sequential(*stage_modules))
-        return stages
+        if not hasattr(self, "stages"):   
+            self.stages = []
+            stage_modules = []
+            for module in self.features:
+                if isinstance(module, nn.MaxPool2d):
+                    self.stages.append(nn.Sequential(*stage_modules))
+                    stage_modules = []
+                stage_modules.append(module)
+            self.stages.append(nn.Sequential(*stage_modules))
+        return self.stages
 
     def forward(self, x):
         stages = self.get_stages()

--- a/segmentation_models_pytorch/encoders/xception.py
+++ b/segmentation_models_pytorch/encoders/xception.py
@@ -27,15 +27,17 @@ class XceptionEncoder(Xception, EncoderMixin):
                          "due to pooling operation for downsampling!")
 
     def get_stages(self):
-        return [
-            nn.Identity(),
-            nn.Sequential(self.conv1, self.bn1, self.relu, self.conv2, self.bn2, self.relu),
-            self.block1,
-            self.block2,
-            nn.Sequential(self.block3, self.block4, self.block5, self.block6, self.block7,
-                          self.block8, self.block9, self.block10, self.block11),
-            nn.Sequential(self.block12, self.conv3, self.bn3, self.relu, self.conv4, self.bn4),
-        ]
+        if not hasattr(self, "stages"): 
+            self.stages = [
+                nn.Identity(),
+                nn.Sequential(self.conv1, self.bn1, self.relu, self.conv2, self.bn2, self.relu),
+                self.block1,
+                self.block2,
+                nn.Sequential(self.block3, self.block4, self.block5, self.block6, self.block7,
+                              self.block8, self.block9, self.block10, self.block11),
+                nn.Sequential(self.block12, self.conv3, self.bn3, self.relu, self.conv4, self.bn4),
+            ]
+        return self.stages
 
     def forward(self, x):
         stages = self.get_stages()


### PR DESCRIPTION
GPU memory usage increases after every forward pass, because new modules are created every time get_stages() is called. This crashes runtime after a while, even if the model is used for inference only.