### PR TITLE
Wrong losses constant description

### DIFF
--- a/segmentation_models_pytorch/losses/constants.py
+++ b/segmentation_models_pytorch/losses/constants.py
@@ -4,15 +4,15 @@
 #: Target mask shape - (N, H, W), model output mask shape (N, 1, H, W).
 BINARY_MODE: str = "binary"
 
+#: Loss multiclass mode suppose you are solving multi-**class** segmentation task.
+#: That mean you have *C = 1..N* classes which have unique label values,
+#: classes are mutually exclusive and all pixels are labeled with theese values.
+#: Target mask shape - (N, H, W), model output mask shape (N, C, H, W).  
+MULTICLASS_MODE: str = "multiclass"
+
 #: Loss multilabel mode suppose you are solving multi-**label** segmentation task.
 #: That mean you have *C = 1..N* classes which pixels are labeled as **1**,
 #: classes are not mutually exclusive and each class have its own *channel*,
 #: pixels in each channel which are not belong to class labeled as **0**.
 #: Target mask shape - (N, C, H, W), model output mask shape (N, C, H, W).
-MULTICLASS_MODE: str = "multiclass"
-
-#: Loss multiclass mode suppose you are solving multi-**class** segmentation task.
-#: That mean you have *C = 1..N* classes which have unique label values,
-#: classes are mutually exclusive and all pixels are labeled with theese values.
-#: Target mask shape - (N, H, W), model output mask shape (N, C, H, W).
 MULTILABEL_MODE: str = "multilabel"


### PR DESCRIPTION
The description of constant 'multilabel' and 'multiclass' in the losses module are mixed up