### PR TITLE
Added weights copy initialization mode

### DIFF
--- a/segmentation_models_pytorch/deeplabv3/model.py
+++ b/segmentation_models_pytorch/deeplabv3/model.py
@@ -44,6 +44,7 @@ class DeepLabV3(SegmentationModel):
             encoder_name: str = "resnet34",
             encoder_depth: int = 5,
             encoder_weights: Optional[str] = "imagenet",
+            encoder_weights_init_mode: Optional[str] = None,
             decoder_channels: int = 256,
             in_channels: int = 3,
             classes: int = 1,
@@ -58,6 +59,7 @@ class DeepLabV3(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
         self.encoder.make_dilated(
             stage_list=[4, 5],
@@ -125,6 +127,7 @@ class DeepLabV3Plus(SegmentationModel):
             encoder_name: str = "resnet34",
             encoder_depth: int = 5,
             encoder_weights: Optional[str] = "imagenet",
+            encoder_weights_init_mode: Optional[str] = None,
             encoder_output_stride: int = 16,
             decoder_channels: int = 256,
             decoder_atrous_rates: tuple = (12, 24, 36),
@@ -141,6 +144,7 @@ class DeepLabV3Plus(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         if encoder_output_stride == 8:

--- a/segmentation_models_pytorch/deeplabv3/model.py
+++ b/segmentation_models_pytorch/deeplabv3/model.py
@@ -18,6 +18,9 @@ class DeepLabV3(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         decoder_channels: A number of convolution filters in ASPP module. Default is 256
         in_channels: A number of input channels for the model, default is 3 (RGB images)
         classes: A number of classes for output mask (or you can think as a number of channels of output mask)
@@ -100,6 +103,9 @@ class DeepLabV3Plus(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         encoder_output_stride: Downsampling factor for last encoder features (see original paper for explanation)
         decoder_atrous_rates: Dilation rates for ASPP module (should be a tuple of 3 integer values)
         decoder_channels: A number of convolution filters in ASPP module. Default is 256

--- a/segmentation_models_pytorch/encoders/__init__.py
+++ b/segmentation_models_pytorch/encoders/__init__.py
@@ -36,7 +36,7 @@ encoders.update(timm_regnet_encoders)
 encoders.update(timm_sknet_encoders)
 
 
-def get_encoder(name, in_channels=3, depth=5, weights=None):
+def get_encoder(name, in_channels=3, depth=5, weights=None, weights_init_mode=None):
 
     try:
         Encoder = encoders[name]["encoder"]
@@ -56,7 +56,7 @@ def get_encoder(name, in_channels=3, depth=5, weights=None):
             ))
         encoder.load_state_dict(model_zoo.load_url(settings["url"]))
 
-    encoder.set_in_channels(in_channels)
+    encoder.set_in_channels(in_channels, weights_init_mode)
 
     return encoder
 

--- a/segmentation_models_pytorch/encoders/__init__.py
+++ b/segmentation_models_pytorch/encoders/__init__.py
@@ -56,7 +56,7 @@ def get_encoder(name, in_channels=3, depth=5, weights=None, weights_init_mode=No
             ))
         encoder.load_state_dict(model_zoo.load_url(settings["url"]))
 
-    encoder.set_in_channels(in_channels, weights_init_mode)
+    encoder.set_in_channels(in_channels, weights_init_mode if weights is not None else None)
 
     return encoder
 

--- a/segmentation_models_pytorch/encoders/_base.py
+++ b/segmentation_models_pytorch/encoders/_base.py
@@ -17,7 +17,7 @@ class EncoderMixin:
         """Return channels dimensions for each tensor of forward output of encoder"""
         return self._out_channels[: self._depth + 1]
 
-    def set_in_channels(self, in_channels, weights_init_mode=None):
+    def set_in_channels(self, in_channels, weights_init_mode):
         """Change first convolution channels"""
         if in_channels == 3:
             return

--- a/segmentation_models_pytorch/encoders/_base.py
+++ b/segmentation_models_pytorch/encoders/_base.py
@@ -17,7 +17,7 @@ class EncoderMixin:
         """Return channels dimensions for each tensor of forward output of encoder"""
         return self._out_channels[: self._depth + 1]
 
-    def set_in_channels(self, in_channels):
+    def set_in_channels(self, in_channels, weights_init_mode=None):
         """Change first convolution channels"""
         if in_channels == 3:
             return
@@ -26,7 +26,7 @@ class EncoderMixin:
         if self._out_channels[0] == 3:
             self._out_channels = tuple([in_channels] + list(self._out_channels)[1:])
 
-        utils.patch_first_conv(model=self, in_channels=in_channels)
+        utils.patch_first_conv(model=self, in_channels=in_channels, weights_init_mode=weights_init_mode)
 
     def get_stages(self):
         """Method should be overridden in encoder"""

--- a/segmentation_models_pytorch/encoders/_utils.py
+++ b/segmentation_models_pytorch/encoders/_utils.py
@@ -64,7 +64,7 @@ def patch_first_conv(model, in_channels, weights_init_mode):
                     dst_in_size,
                     *module.kernel_size
                 )
-            elif weights_init_mode == 'copy_init':
+            elif weights_init_mode == "copy_init":
                 new_weight = _get_copied_weights(3, dst_in_size, module)
             else:
                 raise ValueError("Wrong weights initialization mode. Available options are: 'copy_init' or None")

--- a/segmentation_models_pytorch/encoders/_utils.py
+++ b/segmentation_models_pytorch/encoders/_utils.py
@@ -53,9 +53,9 @@ def patch_first_conv(model, in_channels, weights_init_mode):
         new_weight = _get_copied_weights(1, dst_in_size, module)
     else:  # module.groups == 1
         if in_channels == 1:
-            weight = weight.sum(1, keepdim=True)
+            new_weight = weight.sum(1, keepdim=True)
         elif in_channels == 2:
-            weight = weight[:, :2] * (3.0 / 2.0)
+            new_weight = weight[:, :2] * (3.0 / 2.0)
         else:
             if weights_init_mode is None:
                 reset = True

--- a/segmentation_models_pytorch/encoders/_utils.py
+++ b/segmentation_models_pytorch/encoders/_utils.py
@@ -38,7 +38,7 @@ def patch_first_conv(model, in_channels, weights_init_mode):
 
     # change input channels for first conv
     if in_channels % module.groups > 0:
-        raise ValueError(f"Try to change layer input channels to {in_channels} that is not divisible by groups={module.groups}")
+        raise ValueError(f"Couldn't change layer input channels to {in_channels} that is not divisible by groups={module.groups}")
 
     module.in_channels = in_channels
     weight = module.weight.detach()

--- a/segmentation_models_pytorch/fpn/model.py
+++ b/segmentation_models_pytorch/fpn/model.py
@@ -46,6 +46,7 @@ class FPN(SegmentationModel):
         encoder_name: str = "resnet34",
         encoder_depth: int = 5,
         encoder_weights: Optional[str] = "imagenet",
+        encoder_weights_init_mode: Optional[str] = None,
         decoder_pyramid_channels: int = 256,
         decoder_segmentation_channels: int = 128,
         decoder_merge_policy: str = "add",
@@ -63,6 +64,7 @@ class FPN(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         self.decoder = FPNDecoder(

--- a/segmentation_models_pytorch/fpn/model.py
+++ b/segmentation_models_pytorch/fpn/model.py
@@ -16,6 +16,9 @@ class FPN(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         decoder_pyramid_channels: A number of convolution filters in Feature Pyramid of FPN_
         decoder_segmentation_channels: A number of convolution filters in segmentation blocks of FPN_
         decoder_merge_policy: Determines how to merge pyramid features inside FPN. Available options are **add** and **cat**

--- a/segmentation_models_pytorch/linknet/model.py
+++ b/segmentation_models_pytorch/linknet/model.py
@@ -22,6 +22,9 @@ class Linknet(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         decoder_use_batchnorm: If **True**, BatchNorm2d layer between Conv2D and Activation layers
             is used. If **"inplace"** InplaceABN will be used, allows to decrease memory consumption.
             Available options are **True, False, "inplace"**

--- a/segmentation_models_pytorch/linknet/model.py
+++ b/segmentation_models_pytorch/linknet/model.py
@@ -49,6 +49,7 @@ class Linknet(SegmentationModel):
         encoder_name: str = "resnet34",
         encoder_depth: int = 5,
         encoder_weights: Optional[str] = "imagenet",
+        encoder_weights_init_mode: Optional[str] = None,
         decoder_use_batchnorm: bool = True,
         in_channels: int = 3,
         classes: int = 1,
@@ -62,6 +63,7 @@ class Linknet(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         self.decoder = LinknetDecoder(

--- a/segmentation_models_pytorch/manet/model.py
+++ b/segmentation_models_pytorch/manet/model.py
@@ -53,6 +53,7 @@ class MAnet(SegmentationModel):
         encoder_name: str = "resnet34",
         encoder_depth: int = 5,
         encoder_weights: Optional[str] = "imagenet",
+        encoder_weights_init_mode: Optional[str] = None,
         decoder_use_batchnorm: bool = True,
         decoder_channels: List[int] = (256, 128, 64, 32, 16),
         decoder_pab_channels: int = 64,
@@ -68,6 +69,7 @@ class MAnet(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         self.decoder = MAnetDecoder(

--- a/segmentation_models_pytorch/manet/model.py
+++ b/segmentation_models_pytorch/manet/model.py
@@ -21,6 +21,9 @@ class MAnet(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         decoder_channels: List of integers which specify **in_channels** parameter for convolutions used in decoder.
             Length of the list should be the same as **encoder_depth**
         decoder_use_batchnorm: If **True**, BatchNorm2d layer between Conv2D and Activation layers

--- a/segmentation_models_pytorch/pan/model.py
+++ b/segmentation_models_pytorch/pan/model.py
@@ -45,6 +45,7 @@ class PAN(SegmentationModel):
             self,
             encoder_name: str = "resnet34",
             encoder_weights: Optional[str] = "imagenet",
+            encoder_weights_init_mode: Optional[str] = None,
             encoder_dilation: bool = True,
             decoder_channels: int = 32,
             in_channels: int = 3,
@@ -60,6 +61,7 @@ class PAN(SegmentationModel):
             in_channels=in_channels,
             depth=5,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         if encoder_dilation:

--- a/segmentation_models_pytorch/pan/model.py
+++ b/segmentation_models_pytorch/pan/model.py
@@ -17,6 +17,9 @@ class PAN(SegmentationModel):
             to extract features of different spatial resolution
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         encoder_dilation: Flag to use dilation in encoder last layer. Doesn't work with ***ception***, **vgg***, 
             **densenet*`** backbones, default is **True**
         decoder_channels: A number of convolution layer filters in decoder blocks

--- a/segmentation_models_pytorch/pspnet/model.py
+++ b/segmentation_models_pytorch/pspnet/model.py
@@ -51,6 +51,7 @@ class PSPNet(SegmentationModel):
         self,
         encoder_name: str = "resnet34",
         encoder_weights: Optional[str] = "imagenet",
+        encoder_weights_init_mode: Optional[str] = None,
         encoder_depth: int = 3,
         psp_out_channels: int = 512,
         psp_use_batchnorm: bool = True,
@@ -68,6 +69,7 @@ class PSPNet(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         self.decoder = PSPDecoder(

--- a/segmentation_models_pytorch/pspnet/model.py
+++ b/segmentation_models_pytorch/pspnet/model.py
@@ -22,6 +22,9 @@ class PSPNet(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         psp_out_channels: A number of filters in Spatial Pyramid
         psp_use_batchnorm: If **True**, BatchNorm2d layer between Conv2D and Activation layers
             is used. If **"inplace"** InplaceABN will be used, allows to decrease memory consumption.

--- a/segmentation_models_pytorch/unet/model.py
+++ b/segmentation_models_pytorch/unet/model.py
@@ -52,6 +52,7 @@ class Unet(SegmentationModel):
         encoder_name: str = "resnet34",
         encoder_depth: int = 5,
         encoder_weights: Optional[str] = "imagenet",
+        encoder_weights_init_mode: Optional[str] = None,
         decoder_use_batchnorm: bool = True,
         decoder_channels: List[int] = (256, 128, 64, 32, 16),
         decoder_attention_type: Optional[str] = None,
@@ -67,6 +68,7 @@ class Unet(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         self.decoder = UnetDecoder(

--- a/segmentation_models_pytorch/unet/model.py
+++ b/segmentation_models_pytorch/unet/model.py
@@ -20,6 +20,9 @@ class Unet(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         decoder_channels: List of integers which specify **in_channels** parameter for convolutions used in decoder.
             Length of the list should be the same as **encoder_depth**
         decoder_use_batchnorm: If **True**, BatchNorm2d layer between Conv2D and Activation layers

--- a/segmentation_models_pytorch/unetplusplus/model.py
+++ b/segmentation_models_pytorch/unetplusplus/model.py
@@ -52,6 +52,7 @@ class UnetPlusPlus(SegmentationModel):
         encoder_name: str = "resnet34",
         encoder_depth: int = 5,
         encoder_weights: Optional[str] = "imagenet",
+        encoder_weights_init_mode: Optional[str] = None,
         decoder_use_batchnorm: bool = True,
         decoder_channels: List[int] = (256, 128, 64, 32, 16),
         decoder_attention_type: Optional[str] = None,
@@ -67,6 +68,7 @@ class UnetPlusPlus(SegmentationModel):
             in_channels=in_channels,
             depth=encoder_depth,
             weights=encoder_weights,
+            weights_init_mode=encoder_weights_init_mode,
         )
 
         self.decoder = UnetPlusPlusDecoder(

--- a/segmentation_models_pytorch/unetplusplus/model.py
+++ b/segmentation_models_pytorch/unetplusplus/model.py
@@ -20,6 +20,9 @@ class UnetPlusPlus(SegmentationModel):
             Default is 5
         encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and 
             other pretrained weights (see table with available weights for each encoder_name)
+        encoder_weights_init_mode: Encoder weights initialization mode.
+            Available options are **"copy_init"** and **None**.
+            Default is **None**
         decoder_channels: List of integers which specify **in_channels** parameter for convolutions used in decoder.
             Length of the list should be the same as **encoder_depth**
         decoder_use_batchnorm: If **True**, BatchNorm2d layer between Conv2D and Activation layers

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -118,6 +118,23 @@ def test_in_channels(model_class, encoder_name, in_channels):
 
 
 @pytest.mark.parametrize("encoder_name", ENCODERS)
+@pytest.mark.parametrize("encoder_weights_init_mode", [None, "copy_init"])
+@pytest.mark.parametrize("in_channels", [1, 2, 3, 4, 5, 6])
+def test_weights_init_mode(model_class, encoder_name, encoder_weights_init_mode, in_channels):
+    encoder = smp.encoders.get_encoder(
+        encoder_name,
+        in_channels=in_channels,
+        encoder_weights_init_mode=encoder_weights_init_mode)
+
+    encoder.eval()
+    with torch.no_grad():
+        sample = torch.ones([1, in_channels, 64, 64])
+        output = encoder(sample)
+
+    assert model.encoder._in_channels == in_channels
+
+
+@pytest.mark.parametrize("encoder_name", ENCODERS)
 def test_dilation(encoder_name):
     if (encoder_name in ['inceptionresnetv2', 'xception', 'inceptionv4'] or
             encoder_name.startswith('vgg') or encoder_name.startswith('densenet') or

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -120,7 +120,7 @@ def test_in_channels(model_class, encoder_name, in_channels):
 @pytest.mark.parametrize("encoder_name", ENCODERS)
 @pytest.mark.parametrize("encoder_weights_init_mode", [None, "copy_init"])
 @pytest.mark.parametrize("in_channels", [1, 2, 3, 4, 5, 6])
-def test_weights_init_mode(model_class, encoder_name, encoder_weights_init_mode, in_channels):
+def test_weights_init_mode(encoder_name, encoder_weights_init_mode, in_channels):
     encoder = smp.encoders.get_encoder(
         encoder_name,
         in_channels=in_channels,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -105,31 +105,18 @@ def test_upsample(model_class, upsampling):
 
 
 @pytest.mark.parametrize("model_class", [smp.FPN])
-@pytest.mark.parametrize("encoder_name", ENCODERS)
+@pytest.mark.parametrize("encoder_weights", [None, "imagenet"])
+@pytest.mark.parametrize("encoder_weights_init_mode", [None, "copy_init"])
 @pytest.mark.parametrize("in_channels", [1, 2, 4])
-def test_in_channels(model_class, encoder_name, in_channels):
+def test_in_channels(model_class, encoder_weights, encoder_weights_init_mode, in_channels):
     sample = torch.ones([1, in_channels, 64, 64])
-    model = model_class(DEFAULT_ENCODER, encoder_weights=None, in_channels=in_channels)
+    model = model_class(DEFAULT_ENCODER,
+                        encoder_weights=encoder_weights,
+                        encoder_weights_init_mode=encoder_weights_init_mode,
+                        in_channels=in_channels)
     model.eval()
     with torch.no_grad():
         model(sample)
-
-    assert model.encoder._in_channels == in_channels
-
-
-@pytest.mark.parametrize("encoder_name", ENCODERS)
-@pytest.mark.parametrize("encoder_weights_init_mode", [None, "copy_init"])
-@pytest.mark.parametrize("in_channels", [1, 2, 3, 4, 5, 6])
-def test_weights_init_mode(encoder_name, encoder_weights_init_mode, in_channels):
-    encoder = smp.encoders.get_encoder(
-        encoder_name,
-        in_channels=in_channels,
-        encoder_weights_init_mode=encoder_weights_init_mode)
-
-    encoder.eval()
-    with torch.no_grad():
-        sample = torch.ones([1, in_channels, 64, 64])
-        output = encoder(sample)
 
     assert model.encoder._in_channels == in_channels
 


### PR DESCRIPTION
Added `encoder_weights_init_mode` parameter for model initialization. The parameter can be `None` (keeps a random initialization) or `"copy_init"` (see CoinNet for details http://levir.buaa.edu.cn/publications/coinnet.pdf)