### PR TITLE
Bumping up timm version from "==0.3.2" to ">=0.3.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 torchvision>=0.3.0
 pretrainedmodels==0.7.4
 efficientnet-pytorch==0.6.3
-timm==0.3.2
+timm>=0.3.2


### PR DESCRIPTION
Refer to issue #417.

Making minimal changes first to avoid breaking any functionality. Will see if `timm==0.4.9` works fine in a future pull request.