### PR TITLE
Fix timm universal prefix replacement

### DIFF
--- a/segmentation_models_pytorch/encoders/__init__.py
+++ b/segmentation_models_pytorch/encoders/__init__.py
@@ -46,7 +46,7 @@ encoders.update(timm_gernet_encoders)
 def get_encoder(name, in_channels=3, depth=5, weights=None, output_stride=32, **kwargs):
 
     if name.startswith("tu-"):
-        name = name.lstrip("tu-")
+        name = name[3:]
         encoder = TimmUniversalEncoder(
             name=name,
             in_channels=in_channels,


### PR DESCRIPTION
Thanks to all contributors for building wonderful project.

Timm universal feature is a great feature and am using it joyfully. However, I found small bug in here 

https://github.com/qubvel/segmentation_models.pytorch/blob/master/segmentation_models_pytorch/encoders/__init__.py#L49

This line makes encoder name starts with "tu-tf.." to "f.."

```
>>> a = "tu-tf_"
>>> a.lstrip("tu-")
'f_'
```

Since lstrip is working with combination of charactors according to the [documentation](https://docs.python.org/3/library/stdtypes.html#str.lstrip), the lstrip function for replacing `tu-` prefix is giving unexpected behavior. So, I made a small fix for it.

Not sure you accept this small PR contribution, but would be happy if it is fixed.