### PR TITLE
fix bug in lovasz loss

### DIFF
--- a/segmentation_models_pytorch/losses/lovasz.py
+++ b/segmentation_models_pytorch/losses/lovasz.py
@@ -148,7 +148,7 @@ def _flatten_probas(probas, labels, ignore=None):
         probas = probas.view(B, 1, H, W)
 
     C = probas.size(1)
-    probas = torch.movedim(probas, 0, -1)  # [B, C, Di, Dj, Dk...] -> [B, C, Di...Dk, C]
+    probas = torch.movedim(probas, 1, -1)  # [B, C, Di, Dj, ...] -> [B, Di, Dj, ..., C]
     probas = probas.contiguous().view(-1, C)  # [P, C]
 
     labels = labels.view(-1)


### PR DESCRIPTION
In original [LovaszSoftmax repo](https://github.com/bermanmaxim/LovaszSoftmax/blob/7d48792d35a04d3167de488dd00daabbccd8334b/pytorch/lovasz_losses.py#L211):
```python
probas = probas.permute(0, 2, 3, 1).contiguous().view(-1, C)  # B * H * W, C = P, C
```

So, this code in repo:

https://github.com/qubvel/segmentation_models.pytorch/blob/ec807040a580b6c5cb01240bf1fd275100c1858d/segmentation_models_pytorch/losses/lovasz.py#L151

should be changed to:

```python
probas = torch.movedim(probas, 1, -1)
```