### PR TITLE
Fix the wrong stat and accuracy calculation

### DIFF
--- a/segmentation_models_pytorch/metrics/functional.py
+++ b/segmentation_models_pytorch/metrics/functional.py
@@ -172,7 +172,8 @@ def _get_stats_multiclass(
     for i in range(batch_size):
         target_i = target[i]
         output_i = output[i]
-        matched = target_i * (output_i == target_i)
+        mask = output_i == target_i
+        matched = torch.where(mask, target_i, -1)
         tp = torch.histc(matched.float(), bins=num_classes, min=0, max=num_classes - 1)
         fp = torch.histc(output_i.float(), bins=num_classes, min=0, max=num_classes - 1) - tp
         fn = torch.histc(target_i.float(), bins=num_classes, min=0, max=num_classes - 1) - tp
@@ -295,7 +296,7 @@ def _iou_score(tp, fp, fn, tn):
 
 
 def _accuracy(tp, fp, fn, tn):
-    return tp / (tp + fp + fn + tn)
+    return (tp + tn) / (tp + fp + fn + tn)
 
 
 def _sensitivity(tp, fp, fn, tn):


### PR DESCRIPTION
Two bugs are fixed in this pr.
- `get_stats` under multiclass mode. `matched = target_i * (output_i == target_i)` Wrong predictions will be treated as a matched prediction for class 0.
- `_accuracy`. Only true-positive is counted, true-negative should also be included.

One more question. Two kinds of APIs are provided for metric calculation, the one under utils and the one under metrics, which one is more preferable?