### PR TITLE
fix issue qubvel/segmentation_models.pytorch#377

### DIFF
--- a/segmentation_models_pytorch/decoders/deeplabv3/model.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/model.py
@@ -153,6 +153,7 @@ class DeepLabV3Plus(SegmentationModel):
 
         self.decoder = DeepLabV3PlusDecoder(
             encoder_channels=self.encoder.out_channels,
+            encoder_depth=encoder_depth,
             out_channels=decoder_channels,
             atrous_rates=decoder_atrous_rates,
             output_stride=encoder_output_stride,

--- a/segmentation_models_pytorch/decoders/deeplabv3/model.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/model.py
@@ -108,7 +108,8 @@ class DeepLabV3Plus(SegmentationModel):
             Available options are **"sigmoid"**, **"softmax"**, **"logsoftmax"**, **"tanh"**, **"identity"**,
                 **callable** and **None**.
             Default is **None**
-        upsampling: Final upsampling factor. Default is 4 to preserve input-output spatial shape identity
+        upsampling: Final upsampling factor. Default is 4 to preserve input-output spatial shape identity. In case
+            **encoder_depth** and **encoder_output_stride** are 3 and 16 resp., set **upsampling** to 2 to preserve.
         aux_params: Dictionary with parameters of the auxiliary output (classification head). Auxiliary output is build
             on top of encoder if **aux_params** is not **None** (default). Supported params:
                 - classes (int): A number of classes


### PR DESCRIPTION
Hi! Thank you for sharing your great work.

I faced the issue #377 and tried to fix it.
I have found that the tensor shapes of `aspp_features` and `high_res_features` in `DeepLabV3PlusDecoder.forward` do not match, and they cannot be concatenated.

After some investigation, the index for the encoder output that `DeepLabV3PlusDecoder.block1` should accept need to be set suitable for the value of `encoder_depth` and `encoder_output_stride`.

Just for your information, I attach a text to see the combination of tensor shapes.
[tensor_shapes.md](https://github.com/qubvel/segmentation_models.pytorch/files/8053614/tensor_shapes.md)

I appreciate any comment. Thanks in advance!

(edit)
I noticed that in case `encoder_depth` and `encoder_output_stride` are 3 and 16 respectively, the argument `upsampling` of  `DeepLabV3Plus` needs to be set to 2 to obtain the same output shape as input.

I think this setting of `upsampling` may be included in docstring, and made another commit in the pull request.