### PR TITLE
Fix: soft_dice_score

### DIFF
--- a/segmentation_models_pytorch/losses/_functional.py
+++ b/segmentation_models_pytorch/losses/_functional.py
@@ -172,11 +172,13 @@ def soft_dice_score(
     assert output.size() == target.size()
     if dims is not None:
         intersection = torch.sum(output * target, dim=dims)
-        cardinality = torch.sum(output + target, dim=dims)
+        fp = torch.sum(output * (1.0 - target), dim=dims)
+        fn = torch.sum((1 - output) * target, dim=dims)
     else:
         intersection = torch.sum(output * target)
-        cardinality = torch.sum(output + target)
-    dice_score = (2.0 * intersection + smooth) / (cardinality + smooth).clamp_min(eps)
+        fp = torch.sum(output * (1.0 - target))
+        fn = torch.sum((1 - output) * target)
+    dice_score = (2.0 * intersection + smooth)/(2 * intersection + fn + fp + smooth).clamp_min(eps)
     return dice_score
 
 


### PR DESCRIPTION
Fix soft dice score

I think the part where the denominator needs to be multiplied by 2 in front of the true positive is missing.

As a result of my experiment, the performance was lower than when using loss in utils. (https://github.com/qubvel/segmentation_models.pytorch/blob/master/segmentation_models_pytorch/utils/losses.py#L26-L43)

By replacing the code with the code I requested, the performance improved.

Request you to check!