### PR TITLE
Threshold for Dice loss

### DIFF
--- a/segmentation_models_pytorch/utils/functional.py
+++ b/segmentation_models_pytorch/utils/functional.py
@@ -12,7 +12,7 @@ def _take_channels(*xs, ignore_channels=None):
 
 def _threshold(x, threshold=None):
     if threshold is not None:
-        return (x > threshold).type(x.dtype)
+        return torch.tensor((x > threshold).type(x.dtype),requires_grad=True)
     else:
         return x
 

--- a/segmentation_models_pytorch/utils/losses.py
+++ b/segmentation_models_pytorch/utils/losses.py
@@ -24,12 +24,13 @@ class JaccardLoss(base.Loss):
 
 
 class DiceLoss(base.Loss):
-    def __init__(self, eps=1.0, beta=1.0, activation=None, ignore_channels=None, **kwargs):
+    def __init__(self, eps=1.0, beta=1.0, activation=None, threshold=None, ignore_channels=None, **kwargs):
         super().__init__(**kwargs)
         self.eps = eps
         self.beta = beta
         self.activation = Activation(activation)
         self.ignore_channels = ignore_channels
+        self.threshold=threshold
 
     def forward(self, y_pr, y_gt):
         y_pr = self.activation(y_pr)
@@ -38,7 +39,7 @@ class DiceLoss(base.Loss):
             y_gt,
             beta=self.beta,
             eps=self.eps,
-            threshold=None,
+            threshold=self.threshold,
             ignore_channels=self.ignore_channels,
         )
 


### PR DESCRIPTION
Added a threshold parameter for Dice Loss.
    `def __init__(self, eps=1.0, beta=1.0, activation=None, threshold=None, ignore_channels=None, **kwargs):`

After doing so, the `_threshold` function in `utils/functional.py` causes the following error
`element 0 of tensors does not require grad and does not have a grad_fn loss function`

So, fixed that by making the function return a tensor that requires grad as follows
`torch.tensor((x > threshold).type(x.dtype),requires_grad=True)`
