### PR TITLE
Fix for smp.losses functions during training

### DIFF
--- a/segmentation_models_pytorch/utils/train.py
+++ b/segmentation_models_pytorch/utils/train.py
@@ -53,7 +53,7 @@ class Epoch:
                 # update loss logs
                 loss_value = loss.cpu().detach().numpy()
                 loss_meter.add(loss_value)
-                loss_logs = {self.loss.__name__: loss_meter.mean}
+                loss_logs = {self.loss.__class__.__name__: loss_meter.mean}
                 logs.update(loss_logs)
 
                 # update metrics logs


### PR DESCRIPTION
Throws AttributeError should a user chooses to utilize any loss function from 'segmentation_models_pytorch.losses'