### PR TITLE
Update the description of TverskyLoss

### DIFF
--- a/segmentation_models_pytorch/losses/tversky.py
+++ b/segmentation_models_pytorch/losses/tversky.py
@@ -10,7 +10,7 @@ __all__ = ["TverskyLoss"]
 
 class TverskyLoss(DiceLoss):
     """Tversky loss for image segmentation task.
-    Where TP and FP is weighted by alpha and beta params.
+    Where FP and FN is weighted by alpha and beta params.
     With alpha == beta == 0.5, this loss becomes equal DiceLoss.
     It supports binary, multiclass and multilabel cases
 


### PR DESCRIPTION
I think you should rethink the description of the [Tversky loss function](https://smp.readthedocs.io/en/latest/losses.html#:~:text=Tversky%20loss%20for%20image%20segmentation%20task.%20Where%20TP%20and%20FP%20is%20weighted%20by%20alpha%20and%20beta%20params.%20With%20alpha%20%3D%3D%20beta%20%3D%3D%200.5%2C%20this%20loss%20becomes%20equal%20DiceLoss.%20It%20supports%20binary%2C%20multiclass%20and%20multilabel%20cases).
You can check the article and see that FN and FP are alpha and beta weighted, while your description says that the loss function weights TP and FP. But the function itself is implemented correctly.