### PR TITLE
Requesting to merge auxiliary CNNs support back to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,8 @@ def custom_loss(pred, target):
    loss = binary_cross_entropy(pred[-1], target) # the main output
    alpha = 2
    for i in range(len(pred)-2, -1, -1):
-      loss += binary_cross_entropy(pred[i], Resize(pred[i].shape[2:], interpolation=InterpolationMode.NEAREST)(target))/(2**alpha) # auxiliary output losses downweighted by 2^alpha and calculated versus lower resolution versions of the target
+      loss += binary_cross_entropy(pred[i], Resize(pred[i].shape[2:], interpolation=InterpolationMode.NEAREST)
+                        (target))/(2**alpha) # auxiliary output losses downweighted by 2^alpha and calculated versus lower resolution versions of the target
       alpha += 2
    return loss
 ```

--- a/README.md
+++ b/README.md
@@ -447,10 +447,10 @@ model = Unet(
 
 def custom_loss(pred, target):
    loss = binary_cross_entropy(pred[-1], target) # the main output
-   DW_factor = 4
+   alpha = 2
    for i in range(len(pred)-2, -1, -1):
-      loss += binary_cross_entropy(pred[i], Resize(pred[i].shape[2:], interpolation=InterpolationMode.NEAREST)(target))/(2**DW_factor) # auxiliary output losses downweighted by 2^DW_factor and calculated versus lower resolution versions of the target
-      DW_factor += 2
+      loss += binary_cross_entropy(pred[i], Resize(pred[i].shape[2:], interpolation=InterpolationMode.NEAREST)(target))/(2**alpha) # auxiliary output losses downweighted by 2^alpha and calculated versus lower resolution versions of the target
+      alpha += 2
    return loss
 ```
 

--- a/segmentation_models_pytorch/__version__.py
+++ b/segmentation_models_pytorch/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 3, 0)
+VERSION = (0, 3, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/segmentation_models_pytorch/base/model.py
+++ b/segmentation_models_pytorch/base/model.py
@@ -5,7 +5,11 @@ from . import initialization as init
 class SegmentationModel(torch.nn.Module):
     def initialize(self):
         init.initialize_decoder(self.decoder)
-        init.initialize_head(self.segmentation_head)
+        if hasattr(self, 'segmentation_heads'):
+            for segmentation_head in self.segmentation_heads:
+                init.initialize_head(segmentation_head)
+        else:
+            init.initialize_head(self.segmentation_head)
         if self.classification_head is not None:
             init.initialize_head(self.classification_head)
 
@@ -29,7 +33,10 @@ class SegmentationModel(torch.nn.Module):
         features = self.encoder(x)
         decoder_output = self.decoder(*features)
 
-        masks = self.segmentation_head(decoder_output)
+        if hasattr(self, 'segmentation_heads'):
+            masks = [self.segmentation_heads[i](decoder_output[i]) for i in range(len(decoder_output))]
+        else:
+            masks = self.segmentation_head(decoder_output)
 
         if self.classification_head is not None:
             labels = self.classification_head(features[-1])

--- a/segmentation_models_pytorch/decoders/unet/decoder.py
+++ b/segmentation_models_pytorch/decoders/unet/decoder.py
@@ -124,4 +124,4 @@ class UnetDecoder(nn.Module):
             else:
                 xs.append(x)
 
-        return xs if self.cnns else xs[-1]
+        return xs if self.auxiliary_cnns else xs[-1]

--- a/segmentation_models_pytorch/decoders/unet/decoder.py
+++ b/segmentation_models_pytorch/decoders/unet/decoder.py
@@ -71,6 +71,7 @@ class UnetDecoder(nn.Module):
         use_batchnorm=True,
         attention_type=None,
         center=False,
+        auxiliary_cnns=False,
     ):
         super().__init__()
 
@@ -104,6 +105,7 @@ class UnetDecoder(nn.Module):
             for in_ch, skip_ch, out_ch in zip(in_channels, skip_channels, out_channels)
         ]
         self.blocks = nn.ModuleList(blocks)
+        self.auxiliary_cnns = auxiliary_cnns
 
     def forward(self, *features):
 
@@ -113,9 +115,13 @@ class UnetDecoder(nn.Module):
         head = features[0]
         skips = features[1:]
 
+        xs = None        
         x = self.center(head)
         for i, decoder_block in enumerate(self.blocks):
             skip = skips[i] if i < len(skips) else None
             x = decoder_block(x, skip)
+            if xs is None: xs=[x]
+            else:
+                xs.append(x)
 
-        return x
+        return xs if self.cnns else xs[-1]


### PR DESCRIPTION
This PR is to request to merge auxiliary CNNs support (for the Unet) back to main.

If `auxiliary_cnns = True`, the segmentation model will return auxiliary CNN outputs as per https://arxiv.org/abs/2011.03683 for directly supervising the intermediate layers of the decoder (see README for further details).