### PR TITLE
Make DeepLabV3 + timm-mobilenetv3 scriptable.

### DIFF
--- a/segmentation_models_pytorch/base/model.py
+++ b/segmentation_models_pytorch/base/model.py
@@ -14,8 +14,8 @@ class SegmentationModel(torch.nn.Module):
         h, w = x.shape[-2:]
         output_stride = self.encoder.output_stride
         if h % output_stride != 0 or w % output_stride != 0:
-            new_h = (h // output_stride + 1) * output_stride if h % output_stride != 0 else h
-            new_w = (w // output_stride + 1) * output_stride if w % output_stride != 0 else w
+            new_h = int((h // output_stride + 1) * output_stride) if h % output_stride != 0 else h
+            new_w = int((w // output_stride + 1) * output_stride) if w % output_stride != 0 else w
             raise RuntimeError(
                 f"Wrong input shape height={h}, width={w}. Expected image height and width "
                 f"divisible by {output_stride}. Consider pad your images to shape ({new_h}, {new_w})."
@@ -27,7 +27,7 @@ class SegmentationModel(torch.nn.Module):
         self.check_input_shape(x)
 
         features = self.encoder(x)
-        decoder_output = self.decoder(*features)
+        decoder_output = self.decoder(features)
 
         masks = self.segmentation_head(decoder_output)
 

--- a/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
@@ -30,6 +30,8 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+from typing import List
+
 import torch
 from torch import nn
 from torch.nn import functional as F
@@ -95,7 +97,7 @@ class DeepLabV3PlusDecoder(nn.Module):
             nn.ReLU(),
         )
 
-    def forward(self, *features):
+    def forward(self, features: List[torch.Tensor]):
         aspp_features = self.aspp(features[-1])
         aspp_features = self.up(aspp_features)
         high_res_features = self.block1(features[-4])

--- a/segmentation_models_pytorch/decoders/linknet/decoder.py
+++ b/segmentation_models_pytorch/decoders/linknet/decoder.py
@@ -65,7 +65,7 @@ class LinknetDecoder(nn.Module):
             [DecoderBlock(channels[i], channels[i + 1], use_batchnorm=use_batchnorm) for i in range(n_blocks)]
         )
 
-    def forward(self, *features):
+    def forward(self, features):
         features = features[1:]  # remove first skip
         features = features[::-1]  # reverse channels to start from head of encoder
 

--- a/segmentation_models_pytorch/decoders/manet/decoder.py
+++ b/segmentation_models_pytorch/decoders/manet/decoder.py
@@ -172,7 +172,7 @@ class MAnetDecoder(nn.Module):
         # for the last we dont have skip connection -> use simple decoder block
         self.blocks = nn.ModuleList(blocks)
 
-    def forward(self, *features):
+    def forward(self, features):
 
         features = features[1:]  # remove first skip with same spatial resolution
         features = features[::-1]  # reverse channels to start from head of encoder

--- a/segmentation_models_pytorch/decoders/pan/decoder.py
+++ b/segmentation_models_pytorch/decoders/pan/decoder.py
@@ -176,7 +176,7 @@ class PANDecoder(nn.Module):
             upscale_mode=upscale_mode,
         )
 
-    def forward(self, *features):
+    def forward(self, features):
         bottleneck = features[-1]
         x5 = self.fpa(bottleneck)  # 1/32
         x4 = self.gau3(features[-2], x5)  # 1/16

--- a/segmentation_models_pytorch/decoders/pspnet/decoder.py
+++ b/segmentation_models_pytorch/decoders/pspnet/decoder.py
@@ -69,7 +69,7 @@ class PSPDecoder(nn.Module):
 
         self.dropout = nn.Dropout2d(p=dropout)
 
-    def forward(self, *features):
+    def forward(self, features):
         x = features[-1]
         x = self.psp(x)
         x = self.conv(x)

--- a/segmentation_models_pytorch/decoders/unet/decoder.py
+++ b/segmentation_models_pytorch/decoders/unet/decoder.py
@@ -105,7 +105,7 @@ class UnetDecoder(nn.Module):
         ]
         self.blocks = nn.ModuleList(blocks)
 
-    def forward(self, *features):
+    def forward(self, features):
 
         features = features[1:]  # remove first skip with same spatial resolution
         features = features[::-1]  # reverse channels to start from head of encoder

--- a/segmentation_models_pytorch/decoders/unetplusplus/decoder.py
+++ b/segmentation_models_pytorch/decoders/unetplusplus/decoder.py
@@ -117,7 +117,7 @@ class UnetPlusPlusDecoder(nn.Module):
         self.blocks = nn.ModuleDict(blocks)
         self.depth = len(self.in_channels) - 1
 
-    def forward(self, *features):
+    def forward(self, features):
 
         features = features[1:]  # remove first skip with same spatial resolution
         features = features[::-1]  # reverse channels to start from head of encoder

--- a/segmentation_models_pytorch/encoders/_base.py
+++ b/segmentation_models_pytorch/encoders/_base.py
@@ -1,8 +1,3 @@
-import torch
-import torch.nn as nn
-from typing import List
-from collections import OrderedDict
-
 from . import _utils as utils
 
 

--- a/segmentation_models_pytorch/encoders/_base.py
+++ b/segmentation_models_pytorch/encoders/_base.py
@@ -30,7 +30,7 @@ class EncoderMixin:
 
         self._in_channels = in_channels
         if self._out_channels[0] == 3:
-            self._out_channels = tuple([in_channels] + list(self._out_channels)[1:])
+            self._out_channels = list([in_channels] + list(self._out_channels)[1:])
 
         utils.patch_first_conv(model=self, new_in_channels=in_channels, pretrained=pretrained)
 

--- a/segmentation_models_pytorch/encoders/mobilenet.py
+++ b/segmentation_models_pytorch/encoders/mobilenet.py
@@ -35,32 +35,33 @@ class MobileNetV2Encoder(torchvision.models.MobileNetV2, EncoderMixin):
         self._depth = depth
         self._out_channels = out_channels
         self._in_channels = 3
+        self._stages = self.get_stages()
         del self.classifier
 
     def get_stages(self):
-        return [
+        return nn.ModuleList([
             nn.Identity(),
             self.features[:2],
             self.features[2:4],
             self.features[4:7],
             self.features[7:14],
             self.features[14:],
-        ]
+        ])
 
     def forward(self, x):
-        stages = self.get_stages()
-
         features = []
-        for i in range(self._depth + 1):
-            x = stages[i](x)
-            features.append(x)
+        for i, stage in enumerate(self._stages):
+            # Note: the somewhat strange format here with `i` is required for conversion to TorchScript.
+            if i <= self._depth:
+                x = stage(x)
+                features.append(x)
 
         return features
 
     def load_state_dict(self, state_dict, **kwargs):
         state_dict.pop("classifier.1.bias", None)
         state_dict.pop("classifier.1.weight", None)
-        super().load_state_dict(state_dict, **kwargs)
+        super().load_state_dict(state_dict, strict=False, **kwargs)
 
 
 mobilenet_encoders = {
@@ -76,7 +77,7 @@ mobilenet_encoders = {
             },
         },
         "params": {
-            "out_channels": (3, 16, 24, 32, 96, 1280),
+            "out_channels": [3, 16, 24, 32, 96, 1280],
         },
     },
 }

--- a/segmentation_models_pytorch/encoders/resnet.py
+++ b/segmentation_models_pytorch/encoders/resnet.py
@@ -41,33 +41,34 @@ class ResNetEncoder(ResNet, EncoderMixin):
         self._out_channels = out_channels
         self._in_channels = 3
 
+        self._stages = self.get_stages()
         del self.fc
         del self.avgpool
 
     def get_stages(self):
-        return [
+        return nn.ModuleList([
             nn.Identity(),
             nn.Sequential(self.conv1, self.bn1, self.relu),
             nn.Sequential(self.maxpool, self.layer1),
             self.layer2,
             self.layer3,
             self.layer4,
-        ]
+        ])
 
     def forward(self, x):
-        stages = self.get_stages()
-
         features = []
-        for i in range(self._depth + 1):
-            x = stages[i](x)
-            features.append(x)
+        for i, stage in enumerate(self._stages):
+            # Note: the somewhat strange format here with `i` is required for conversion to TorchScript.
+            if i <= self._depth:
+                x = stage(x)
+                features.append(x)
 
         return features
 
     def load_state_dict(self, state_dict, **kwargs):
         state_dict.pop("fc.bias", None)
         state_dict.pop("fc.weight", None)
-        super().load_state_dict(state_dict, **kwargs)
+        super().load_state_dict(state_dict, strict=False, **kwargs)
 
 
 new_settings = {
@@ -128,7 +129,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnet18"],
         "params": {
-            "out_channels": (3, 64, 64, 128, 256, 512),
+            "out_channels": [3, 64, 64, 128, 256, 512],
             "block": BasicBlock,
             "layers": [2, 2, 2, 2],
         },
@@ -137,7 +138,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnet34"],
         "params": {
-            "out_channels": (3, 64, 64, 128, 256, 512),
+            "out_channels": [3, 64, 64, 128, 256, 512],
             "block": BasicBlock,
             "layers": [3, 4, 6, 3],
         },
@@ -146,7 +147,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnet50"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 6, 3],
         },
@@ -155,7 +156,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnet101"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 23, 3],
         },
@@ -164,7 +165,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnet152"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 8, 36, 3],
         },
@@ -173,7 +174,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnext50_32x4d"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 6, 3],
             "groups": 32,
@@ -184,7 +185,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnext101_32x4d"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 23, 3],
             "groups": 32,
@@ -195,7 +196,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnext101_32x8d"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 23, 3],
             "groups": 32,
@@ -206,7 +207,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnext101_32x16d"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 23, 3],
             "groups": 32,
@@ -217,7 +218,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnext101_32x32d"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 23, 3],
             "groups": 32,
@@ -228,7 +229,7 @@ resnet_encoders = {
         "encoder": ResNetEncoder,
         "pretrained_settings": pretrained_settings["resnext101_32x48d"],
         "params": {
-            "out_channels": (3, 64, 256, 512, 1024, 2048),
+            "out_channels": [3, 64, 256, 512, 1024, 2048],
             "block": Bottleneck,
             "layers": [3, 4, 23, 3],
             "groups": 32,


### PR DESCRIPTION
This makes at least DeepLabV3 and timm-mobilenetv3 scriptable. I figured this would be a good starting point to discuss if these changes are acceptable.

This PR fixes https://github.com/qubvel/segmentation_models.pytorch/issues/669