### PR TITLE
fix return type of get_stats

### DIFF
--- a/segmentation_models_pytorch/metrics/functional.py
+++ b/segmentation_models_pytorch/metrics/functional.py
@@ -65,7 +65,7 @@ def get_stats(
     ignore_index: Optional[int] = None,
     threshold: Optional[Union[float, List[float]]] = None,
     num_classes: Optional[int] = None,
-) -> Tuple[torch.LongTensor]:
+) -> Tuple[torch.LongTensor, torch.LongTensor, torch.LongTensor, torch.LongTensor]:
     """Compute true positive, false positive, false negative, true negative 'pixels'
     for each image and each class.
 


### PR DESCRIPTION
The previous return type of `Tuple[torch.LongTensor]` implies that the tuple includes one item. This commit changes this to a tuple of four LongTensors to represent TP, FP, FN, and TN.