### PR TITLE
Add ouput_device parameter to get_stats

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,117 @@
+import pytest
+import torch
+import segmentation_models_pytorch as smp
+
+from segmentation_models_pytorch.metrics import get_stats
+
+
+gpu_device = torch.device('cuda:0')
+cpu_device = torch.device('cpu')
+
+
+def test_get_stats_multiclass_input_gpu_output_no_device():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=gpu_device)
+    target = torch.randint(0, 5, size, device=gpu_device)
+
+    stats = get_stats(output, target, mode='multiclass', num_classes=5)
+
+    for s in stats:
+        # default to cpu
+        s.device == cpu_device
+
+
+def test_get_stats_multiclass_input_gpu_output_cpu():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=gpu_device)
+    target = torch.randint(0, 5, size, device=gpu_device)
+
+    stats = get_stats(output, target, mode='multiclass',
+                      num_classes=5, output_device=cpu_device)
+
+    for s in stats:
+        s.device == cpu_device
+
+
+def test_get_stats_multiclass_input_gpu_output_gpu():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=gpu_device)
+    target = torch.randint(0, 5, size, device=gpu_device)
+
+    stats = get_stats(output, target, mode='multiclass',
+                      num_classes=5, output_device=gpu_device)
+
+    for s in stats:
+        s.device == gpu_device
+
+
+def test_get_stats_multiclass_input_cpu_output_no_device():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=cpu_device)
+    target = torch.randint(0, 5, size, device=cpu_device)
+
+    stats = get_stats(output, target, mode='multiclass', num_classes=5)
+
+    for s in stats:
+        # default to cpu
+        s.device == cpu_device
+
+
+def test_get_stats_multiclass_input_cpu_output_cpu():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=cpu_device)
+    target = torch.randint(0, 5, size, device=cpu_device)
+
+    stats = get_stats(output, target, mode='multiclass',
+                      num_classes=5, output_device=cpu_device)
+
+    for s in stats:
+        s.device == cpu_device
+
+
+def test_get_stats_multiclass_input_cpu_output_gpu():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=cpu_device)
+    target = torch.randint(0, 5, size, device=cpu_device)
+
+    stats = get_stats(output, target, mode='multiclass',
+                      num_classes=5, output_device=gpu_device)
+
+    for s in stats:
+        s.device == gpu_device
+
+
+def test_get_stats_multilabel_input_gpu_ouput_no_device():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=gpu_device)
+    target = torch.randint(0, 5, size, device=gpu_device)
+
+    stats = get_stats(output, target, mode='multilabel',
+                      num_classes=5)
+
+    for s in stats:
+        s.device == gpu_device
+
+
+def test_get_stats_multilabel_input_gpu_ouput_gpu():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=gpu_device)
+    target = torch.randint(0, 5, size, device=gpu_device)
+
+    stats = get_stats(output, target, mode='multilabel',
+                      num_classes=5, output_device=gpu_device)
+
+    for s in stats:
+        s.device == gpu_device
+
+
+def test_get_stats_multilabel_input_gpu_ouput_cpu():
+    size = (10, 32, 32)
+    output = torch.randint(0, 5, size, device=gpu_device)
+    target = torch.randint(0, 5, size, device=gpu_device)
+
+    stats = get_stats(output, target, mode='multilabel',
+                      num_classes=5, output_device=cpu_device)
+
+    for s in stats:
+        s.device == cpu_device


### PR DESCRIPTION
Hello. I'm new to using `smp.metrics` (previously I used metric functions from utils), but I would like to propose a change, which is adding `output_device` parameter to `get_stats` function.

I assume that people use this function in `'multiclass'` mode, then follow by function such as `iou_score`.
The problem may arise if people use a function from `torch.distributed` such as `all_reduce` on `nccl` backend, to average metric values across processes, because `all_reduce` function requires tensors to be on GPU, but in the case of multiclass, `get_stats` create zeros tensors with default device option, which puts it in CPU, and later return them, so the device of returned tensors is CPU.

I know that I can move a result stats tensor to GPU and it will be fine, but isn't it more efficient to specify the return type from the beginning? Especially when the output and target tensors are on the returned device already (I don't really know if this is true or not😅).

So, I create this PR to add parameter named `output_device` to `get_stats` function so that `torch.zeros` can create tensor on specified device, and some tests to ensure that it doesn't break existing code.

In the case of binary and multilabel mode, I just move the result tensors to specified device because the result will be on the same device as input already.