### PR TITLE
Fix the focal Tversky loss

### DIFF
--- a/segmentation_models_pytorch/losses/tversky.py
+++ b/segmentation_models_pytorch/losses/tversky.py
@@ -53,7 +53,7 @@ class TverskyLoss(DiceLoss):
         self.gamma = gamma
 
     def aggregate_loss(self, loss):
-        return (loss ** self.gamma).mean()
+        return (loss**self.gamma).mean()
 
     def compute_score(self, output, target, smooth=0.0, eps=1e-7, dims=None) -> torch.Tensor:
         return soft_tversky_score(output, target, self.alpha, self.beta, smooth, eps, dims)


### PR DESCRIPTION
Fix the focal Tversky loss according to Eq (4). of the [paper](https://arxiv.org/pdf/1810.07842.pdf). The gamma term is applied per-class.
