### PR TITLE
Fix improper call to super constructor in FocalLoss; add test case

### DIFF
--- a/segmentation_models_pytorch/losses/focal.py
+++ b/segmentation_models_pytorch/losses/focal.py
@@ -41,7 +41,7 @@ class FocalLoss(_Loss):
 
         """
         assert mode in {BINARY_MODE, MULTILABEL_MODE, MULTICLASS_MODE}
-        super().__init__()
+        super().__init__(reduction=reduction)
 
         self.mode = mode
         self.ignore_index = ignore_index

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -4,6 +4,7 @@ import segmentation_models_pytorch as smp
 import segmentation_models_pytorch.losses._functional as F
 from segmentation_models_pytorch.losses import (
     DiceLoss,
+    FocalLoss,
     JaccardLoss,
     SoftBCEWithLogitsLoss,
     SoftCrossEntropyLoss,
@@ -21,6 +22,17 @@ def test_focal_loss_with_logits():
     loss_bad = F.focal_loss_with_logits(input_bad, target)
     assert loss_good < loss_bad
 
+def test_focal_loss_reduction():
+    input = torch.tensor([10, -10, 10]).float()
+    target = torch.tensor([1, 0, 1])
+
+    loss_fn = FocalLoss(mode="binary", reduction="none")
+    assert loss_fn(input, target).shape == (3,)
+    assert loss_fn.reduction == "none"
+
+    loss_fn = FocalLoss(mode="binary", reduction="mean")
+    assert loss_fn(input, target).shape == ()
+    assert loss_fn.reduction == "mean"
 
 def test_softmax_focal_loss_with_logits():
     input_good = torch.tensor([[0, 10, 0], [10, 0, 0], [0, 0, 10]]).float()


### PR DESCRIPTION
As in the title: `FocalLoss` was not calling super constructor properly so the `FocalLoss.reduction` remained at the default value of `mean` even if the user set it otherwise. This did not impact the functionality but caused assertion errors in my own code. Adding a test case as an extra.