### PR TITLE
Pass kwargs to backbone when creating an encoder.

### DIFF
--- a/segmentation_models_pytorch/encoders/__init__.py
+++ b/segmentation_models_pytorch/encoders/__init__.py
@@ -69,6 +69,7 @@ def get_encoder(name, in_channels=3, depth=5, weights=None, output_stride=32, **
 
     params = encoders[name]["params"]
     params.update(depth=depth)
+    params.update(kwargs)
     encoder = Encoder(**params)
 
     if weights is not None:


### PR DESCRIPTION
get_encoder: pass kwargs to backbone.

I've used this to pass `norm_layer=nn.nn.InstanceNorm2d` to `torchvision.models.resnet()`