### PR TITLE
Support Timm ViTs

### DIFF
--- a/segmentation_models_pytorch/encoders/__init__.py
+++ b/segmentation_models_pytorch/encoders/__init__.py
@@ -22,7 +22,7 @@ from .timm_gernet import timm_gernet_encoders
 from .mix_transformer import mix_transformer_encoders
 from .mobileone import mobileone_encoders
 
-from .timm_universal import TimmUniversalEncoder
+from .timm_universal import TimmUniversalEncoder, TimmUniversalViTEncoder
 
 from ._preprocessing import preprocess_input
 
@@ -49,17 +49,25 @@ encoders.update(mobileone_encoders)
 
 
 def get_encoder(name, in_channels=3, depth=5, weights=None, output_stride=32, **kwargs):
-
     if name.startswith("tu-"):
         name = name[3:]
-        encoder = TimmUniversalEncoder(
-            name=name,
-            in_channels=in_channels,
-            depth=depth,
-            output_stride=output_stride,
-            pretrained=weights is not None,
-            **kwargs,
-        )
+        if name.startswith("vit"):
+            depth = 4
+            encoder = TimmUniversalViTEncoder(
+                name=name,
+                in_channels=in_channels,
+                pretrained=weights is not None,
+                **kwargs,
+            )
+        else:
+            encoder = TimmUniversalEncoder(
+                name=name,
+                in_channels=in_channels,
+                depth=depth,
+                output_stride=output_stride,
+                pretrained=weights is not None,
+                **kwargs,
+            )
         return encoder
 
     try:
@@ -96,7 +104,6 @@ def get_encoder_names():
 
 
 def get_preprocessing_params(encoder_name, pretrained="imagenet"):
-
     if encoder_name.startswith("tu-"):
         encoder_name = encoder_name[3:]
         if not timm.models.is_model_pretrained(encoder_name):

--- a/segmentation_models_pytorch/encoders/timm_universal.py
+++ b/segmentation_models_pytorch/encoders/timm_universal.py
@@ -1,5 +1,6 @@
 import timm
 import torch.nn as nn
+import torch.nn.functional as F
 
 
 class TimmUniversalEncoder(nn.Module):
@@ -40,3 +41,39 @@ class TimmUniversalEncoder(nn.Module):
     @property
     def output_stride(self):
         return min(self._output_stride, 2**self._depth)
+
+
+class TimmUniversalViTEncoder(nn.Module):
+    def __init__(self, name, pretrained=True, in_channels=3, norm=True):
+        super().__init__()
+        kwargs = dict(
+            in_chans=in_channels,
+            pretrained=pretrained,
+        )
+        self.model = timm.create_model(name, **kwargs)
+        self.norm = norm
+        self.indexes = [i for i in range(-1, len(self.model.blocks), len(self.model.blocks) // 4)][1:]
+        self._depth = 4
+        self._in_channels = in_channels
+        self._out_channels = [in_channels] + [self.model.num_features] * len(self.indexes)
+        self.upsample = nn.ModuleList([nn.UpsamplingBilinear2d(scale_factor=s) for s in [16, 8, 4, 2]])
+
+    def forward(self, x):
+        features = self.model.get_intermediate_layers(
+            x, n=self.indexes, reshape=True, return_class_token=False, norm=self.norm
+        )
+        features = [up(f) for up, f in zip(self.upsample, features)]
+        features = [x] + list(features)
+        return features
+
+    @property
+    def out_channels(self):
+        return self._out_channels
+
+    @property
+    def output_stride(self):
+        return self.model.patch_embed.patch_size[0]
+
+    @property
+    def image_size(self):
+        return self.model.patch_embed.img_size[0]


### PR DESCRIPTION
This PR implements a `TimmUniversalViTEncoder` loosely based on [Benchmarking Detection Transfer Learning with Vision Transformers](https://arxiv.org/abs/2111.11429). This is essentially a naive method to upsample features from intermediate transformer encoder blocks to allow for connecting with any of the SMP decoders using timm's `VisionTransformer.get_intermediate_layers` method.

I'm not sold that the upsampling is the right way to support ViT encoders so I'm definitely open to improving this PR.

@adamjstewart @calebrob6