### PR TITLE
Removing EfficientNet model head

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,29 +274,29 @@ The following is a list of supported encoders in the SMP. Select the appropriate
 
 |Encoder                         |Weights                         |Params, M                       |
 |--------------------------------|:------------------------------:|:------------------------------:|
-|efficientnet-b0                 |imagenet                        |4M                              |
+|efficientnet-b0                 |imagenet                        |3M                              |
 |efficientnet-b1                 |imagenet                        |6M                              |
 |efficientnet-b2                 |imagenet                        |7M                              |
 |efficientnet-b3                 |imagenet                        |10M                             |
-|efficientnet-b4                 |imagenet                        |17M                             |
-|efficientnet-b5                 |imagenet                        |28M                             |
-|efficientnet-b6                 |imagenet                        |40M                             |
-|efficientnet-b7                 |imagenet                        |63M                             |
-|timm-efficientnet-b0            |imagenet / advprop / noisy-student|4M                              |
+|efficientnet-b4                 |imagenet                        |16M                             |
+|efficientnet-b5                 |imagenet                        |27M                             |
+|efficientnet-b6                 |imagenet                        |39M                             |
+|efficientnet-b7                 |imagenet                        |62M                             |
+|timm-efficientnet-b0            |imagenet / advprop / noisy-student|3M                              |
 |timm-efficientnet-b1            |imagenet / advprop / noisy-student|6M                              |
 |timm-efficientnet-b2            |imagenet / advprop / noisy-student|7M                              |
 |timm-efficientnet-b3            |imagenet / advprop / noisy-student|10M                             |
-|timm-efficientnet-b4            |imagenet / advprop / noisy-student|17M                             |
-|timm-efficientnet-b5            |imagenet / advprop / noisy-student|28M                             |
-|timm-efficientnet-b6            |imagenet / advprop / noisy-student|40M                             |
-|timm-efficientnet-b7            |imagenet / advprop / noisy-student|63M                             |
-|timm-efficientnet-b8            |imagenet / advprop             |84M                             |
-|timm-efficientnet-l2            |noisy-student                   |474M                            |
-|timm-efficientnet-lite0         |imagenet                        |4M                              |
-|timm-efficientnet-lite1         |imagenet                        |5M                              |
-|timm-efficientnet-lite2         |imagenet                        |6M                              |
-|timm-efficientnet-lite3         |imagenet                        |8M                             |
-|timm-efficientnet-lite4         |imagenet                        |13M                             |
+|timm-efficientnet-b4            |imagenet / advprop / noisy-student|16M                             |
+|timm-efficientnet-b5            |imagenet / advprop / noisy-student|27M                             |
+|timm-efficientnet-b6            |imagenet / advprop / noisy-student|39M                             |
+|timm-efficientnet-b7            |imagenet / advprop / noisy-student|62M                             |
+|timm-efficientnet-b8            |imagenet / advprop             |82M                             |
+|timm-efficientnet-l2            |noisy-student                   |467M                            |
+|timm-efficientnet-lite0         |imagenet                        |2M                              |
+|timm-efficientnet-lite1         |imagenet                        |3M                              |
+|timm-efficientnet-lite2         |imagenet                        |4M                              |
+|timm-efficientnet-lite3         |imagenet                        |6M                             |
+|timm-efficientnet-lite4         |imagenet                        |11M                             |
 
 </div>
 </details>

--- a/README.md
+++ b/README.md
@@ -274,14 +274,14 @@ The following is a list of supported encoders in the SMP. Select the appropriate
 
 |Encoder                         |Weights                         |Params, M                       |
 |--------------------------------|:------------------------------:|:------------------------------:|
-|efficientnet-b0                 |imagenet                        |3M                              |
-|efficientnet-b1                 |imagenet                        |6M                              |
-|efficientnet-b2                 |imagenet                        |7M                              |
-|efficientnet-b3                 |imagenet                        |10M                             |
-|efficientnet-b4                 |imagenet                        |16M                             |
-|efficientnet-b5                 |imagenet                        |27M                             |
-|efficientnet-b6                 |imagenet                        |39M                             |
-|efficientnet-b7                 |imagenet                        |62M                             |
+|efficientnet-b0                 |imagenet / advprop              |3M                              |
+|efficientnet-b1                 |imagenet / advprop              |6M                              |
+|efficientnet-b2                 |imagenet / advprop              |7M                              |
+|efficientnet-b3                 |imagenet / advprop              |10M                             |
+|efficientnet-b4                 |imagenet / advprop              |16M                             |
+|efficientnet-b5                 |imagenet / advprop              |27M                             |
+|efficientnet-b6                 |imagenet / advprop              |39M                             |
+|efficientnet-b7                 |imagenet / advprop              |62M                             |
 |timm-efficientnet-b0            |imagenet / advprop / noisy-student|3M                              |
 |timm-efficientnet-b1            |imagenet / advprop / noisy-student|6M                              |
 |timm-efficientnet-b2            |imagenet / advprop / noisy-student|7M                              |
@@ -291,7 +291,7 @@ The following is a list of supported encoders in the SMP. Select the appropriate
 |timm-efficientnet-b6            |imagenet / advprop / noisy-student|39M                             |
 |timm-efficientnet-b7            |imagenet / advprop / noisy-student|62M                             |
 |timm-efficientnet-b8            |imagenet / advprop             |82M                             |
-|timm-efficientnet-l2            |noisy-student                   |467M                            |
+|timm-efficientnet-l2            |noisy-student / noisy-student-475|467M                            |
 |timm-efficientnet-lite0         |imagenet                        |2M                              |
 |timm-efficientnet-lite1         |imagenet                        |3M                              |
 |timm-efficientnet-lite2         |imagenet                        |4M                              |

--- a/docs/encoders.rst
+++ b/docs/encoders.rst
@@ -215,7 +215,7 @@ EfficientNet
 +------------------------+--------------------------------------+-------------+
 | Encoder                | Weights                              | Params, M   |
 +========================+======================================+=============+
-| efficientnet-b0        | imagenet                             | 4M          |
+| efficientnet-b0        | imagenet                             | 3M          |
 +------------------------+--------------------------------------+-------------+
 | efficientnet-b1        | imagenet                             | 6M          |
 +------------------------+--------------------------------------+-------------+
@@ -223,15 +223,15 @@ EfficientNet
 +------------------------+--------------------------------------+-------------+
 | efficientnet-b3        | imagenet                             | 10M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b4        | imagenet                             | 17M         |
+| efficientnet-b4        | imagenet                             | 16M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b5        | imagenet                             | 28M         |
+| efficientnet-b5        | imagenet                             | 27M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b6        | imagenet                             | 40M         |
+| efficientnet-b6        | imagenet                             | 39M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b7        | imagenet                             | 63M         |
+| efficientnet-b7        | imagenet                             | 62M         |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-b0   | imagenet / advprop / noisy-student   | 4M          |
+| timm-efficientnet-b0   | imagenet / advprop / noisy-student   | 3M          |
 +------------------------+--------------------------------------+-------------+
 | timm-efficientnet-b1   | imagenet / advprop / noisy-student   | 6M          |
 +------------------------+--------------------------------------+-------------+
@@ -239,27 +239,27 @@ EfficientNet
 +------------------------+--------------------------------------+-------------+
 | timm-efficientnet-b3   | imagenet / advprop / noisy-student   | 10M         |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-b4   | imagenet / advprop / noisy-student   | 17M         |
+| timm-efficientnet-b4   | imagenet / advprop / noisy-student   | 16M         |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-b5   | imagenet / advprop / noisy-student   | 28M         |
+| timm-efficientnet-b5   | imagenet / advprop / noisy-student   | 27M         |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-b6   | imagenet / advprop / noisy-student   | 40M         |
+| timm-efficientnet-b6   | imagenet / advprop / noisy-student   | 39M         |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-b7   | imagenet / advprop / noisy-student   | 63M         |
+| timm-efficientnet-b7   | imagenet / advprop / noisy-student   | 62M         |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-b8   | imagenet / advprop                   | 84M         |
+| timm-efficientnet-b8   | imagenet / advprop                   | 82M         |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-l2   | noisy-student / noisy-student-475    | 474M        |
+| timm-efficientnet-l2   | noisy-student / noisy-student-475    | 467M        |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-lite0| imagenet                             | 4M          |
+| timm-efficientnet-lite0| imagenet                             | 2M          |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-lite1| imagenet                             | 4M          |
+| timm-efficientnet-lite1| imagenet                             | 3M          |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-lite2| imagenet                             | 6M          |
+| timm-efficientnet-lite2| imagenet                             | 4M          |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-lite3| imagenet                             | 8M          |
+| timm-efficientnet-lite3| imagenet                             | 6M          |
 +------------------------+--------------------------------------+-------------+
-| timm-efficientnet-lite4| imagenet                             | 13M         |
+| timm-efficientnet-lite4| imagenet                             | 11M         |
 +------------------------+--------------------------------------+-------------+
 
 MobileNet

--- a/docs/encoders.rst
+++ b/docs/encoders.rst
@@ -215,21 +215,21 @@ EfficientNet
 +------------------------+--------------------------------------+-------------+
 | Encoder                | Weights                              | Params, M   |
 +========================+======================================+=============+
-| efficientnet-b0        | imagenet                             | 3M          |
+| efficientnet-b0        | imagenet / advprop                   | 3M          |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b1        | imagenet                             | 6M          |
+| efficientnet-b1        | imagenet / advprop                   | 6M          |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b2        | imagenet                             | 7M          |
+| efficientnet-b2        | imagenet / advprop                   | 7M          |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b3        | imagenet                             | 10M         |
+| efficientnet-b3        | imagenet / advprop                   | 10M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b4        | imagenet                             | 16M         |
+| efficientnet-b4        | imagenet / advprop                   | 16M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b5        | imagenet                             | 27M         |
+| efficientnet-b5        | imagenet / advprop                   | 27M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b6        | imagenet                             | 39M         |
+| efficientnet-b6        | imagenet / advprop                   | 39M         |
 +------------------------+--------------------------------------+-------------+
-| efficientnet-b7        | imagenet                             | 62M         |
+| efficientnet-b7        | imagenet / advprop                   | 62M         |
 +------------------------+--------------------------------------+-------------+
 | timm-efficientnet-b0   | imagenet / advprop / noisy-student   | 3M          |
 +------------------------+--------------------------------------+-------------+

--- a/segmentation_models_pytorch/encoders/efficientnet.py
+++ b/segmentation_models_pytorch/encoders/efficientnet.py
@@ -40,6 +40,8 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
         self._depth = depth
         self._in_channels = 3
 
+        del self._conv_head
+        del self._bn1
         del self._fc
 
     def get_stages(self):

--- a/segmentation_models_pytorch/encoders/efficientnet.py
+++ b/segmentation_models_pytorch/encoders/efficientnet.py
@@ -79,6 +79,13 @@ class EfficientNetEncoder(EfficientNet, EncoderMixin):
         return features
 
     def load_state_dict(self, state_dict, **kwargs):
+        state_dict.pop("_conv_head.bias", None)
+        state_dict.pop("_conv_head.weight", None)
+        state_dict.pop("_bn1.bias", None)
+        state_dict.pop("_bn1.weight", None)
+        state_dict.pop("_bn1.running_mean", None)
+        state_dict.pop("_bn1.running_var", None)
+        state_dict.pop("_bn1.num_batches_tracked", None)
         state_dict.pop("_fc.bias", None)
         state_dict.pop("_fc.weight", None)
         super().load_state_dict(state_dict, **kwargs)

--- a/segmentation_models_pytorch/encoders/timm_efficientnet.py
+++ b/segmentation_models_pytorch/encoders/timm_efficientnet.py
@@ -100,6 +100,8 @@ class EfficientNetBaseEncoder(EfficientNet, EncoderMixin):
         self._depth = depth
         self._in_channels = 3
 
+        del self.conv_head
+        del self.bn2
         del self.classifier
 
     def get_stages(self):

--- a/segmentation_models_pytorch/encoders/timm_efficientnet.py
+++ b/segmentation_models_pytorch/encoders/timm_efficientnet.py
@@ -125,6 +125,14 @@ class EfficientNetBaseEncoder(EfficientNet, EncoderMixin):
         return features
 
     def load_state_dict(self, state_dict, **kwargs):
+        state_dict.pop("conv_head.bias", None)
+        state_dict.pop("conv_head.weight", None)
+        state_dict.pop("bn2.bias", None)
+        state_dict.pop("bn2.weight", None)
+        state_dict.pop("bn2.running_mean", None)
+        state_dict.pop("bn2.running_var", None)
+        state_dict.pop("bn2.num_batches_tracked", None)
+        state_dict.pop("classifier.bias", None)
         state_dict.pop("classifier.bias", None)
         state_dict.pop("classifier.weight", None)
         super().load_state_dict(state_dict, **kwargs)


### PR DESCRIPTION
The EfficientNetEncoders (both the timm and the normal one) have a final expanding 1x1 convolutional layer followed by a batchnorm layer which are not being used in the forward call. I suggest deleting these layers similar to how the fully connected layer is deleted. Deleting these layers saves on some model parameters. 
I came across this when I was training a model in ddp using pytorch-lightning, I was getting an error because some of the model parameters were not being used for calculating the loss and therefore the gradients remain "None" whilst ddp is still trying to sync all the gradients between devices. There is a setting to deal with unused parameters but it makes the training slightly slower.