### PR TITLE
bring __name__ attibute back for lagacy code

### DIFF
--- a/segmentation_models_pytorch/losses/dice.py
+++ b/segmentation_models_pytorch/losses/dice.py
@@ -10,6 +10,9 @@ __all__ = ["DiceLoss"]
 
 
 class DiceLoss(_Loss):
+    def __name__():
+        return "Dice Loss"
+        
     def __init__(
         self,
         mode: str,


### PR DESCRIPTION
Recently, I use an example code provided, and this error arise.

```
AttributeError: 'DiceLoss' object has no attribute '__name__'
```

Therefore, I tried to add it back.