### PR TITLE
Fixes failed export to ONNX when input w/h is dynamic

### DIFF
--- a/segmentation_models_pytorch/encoders/mobileone.py
+++ b/segmentation_models_pytorch/encoders/mobileone.py
@@ -39,6 +39,9 @@ class SEBlock(nn.Module):
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         """Apply forward pass."""
         b, c, h, w = inputs.size()
+        if torch.is_tensor(h):
+             h = h.item()
+             w = w.item()
         x = F.avg_pool2d(inputs, kernel_size=[h, w])
         x = self.reduce(x)
         x = F.relu(x)


### PR DESCRIPTION
This change fixes a failed export to ONNX when using dynamic values for w/h input.  Example export code below:

    input_shape = 1, 3, 640, 640
    feat = torch.randn(input_shape)
    
    input_names = ["input"]
    
    torch.onnx.export(model, feat, 'model.onnx',
                      input_names=input_names,
                      dynamic_axes={'input': {2: 'width', 3: 'height'}},
                      verbose=True, opset_version=18)