### PR TITLE
Fix a potential bug in the `patch_first_conv` function

### DIFF
--- a/segmentation_models_pytorch/encoders/_utils.py
+++ b/segmentation_models_pytorch/encoders/_utils.py
@@ -16,11 +16,9 @@ def patch_first_conv(model, new_in_channels, default_in_channels=3, pretrained=T
 
     weight = module.weight.detach()
     module.in_channels = new_in_channels
-
+    new_in_channels = new_in_channels // module.groups
     if not pretrained:
-        module.weight = nn.parameter.Parameter(
-            torch.Tensor(module.out_channels, new_in_channels // module.groups, *module.kernel_size)
-        )
+        module.weight = nn.parameter.Parameter(torch.Tensor(module.out_channels, new_in_channels, *module.kernel_size))
         module.reset_parameters()
 
     elif new_in_channels == 1:
@@ -28,7 +26,7 @@ def patch_first_conv(model, new_in_channels, default_in_channels=3, pretrained=T
         module.weight = nn.parameter.Parameter(new_weight)
 
     else:
-        new_weight = torch.Tensor(module.out_channels, new_in_channels // module.groups, *module.kernel_size)
+        new_weight = torch.Tensor(module.out_channels, new_in_channels, *module.kernel_size)
 
         for i in range(new_in_channels):
             new_weight[:, i] = weight[:, i % default_in_channels]


### PR DESCRIPTION
The `patch_first_conv` function looks to have a potential bug in the following for-loop because `i` can be larger than `new_weight.shape[1]` (= `new_in_channels // module.groups`)  when groups > 1.

```py
        for i in range(new_in_channels):
            new_weight[:, i] = weight[:, i % default_in_channels]
```

This may not be a problem with the currently supported models, but I think it would be good to correct this.