### PR TITLE
use precommit for code linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,28 +11,9 @@ on:
     branches: [ master ]
 
 jobs:
-  
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install torch==1.9.0+cpu torchvision==0.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-        make install_dev
-    - name: Run Flake8
-      run: make flake8
-    - name: Run Black
-      run: make black
 
   test:
     runs-on: ubuntu-latest
-    needs: [lint]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -44,7 +25,3 @@ jobs:
         python -m pip install --upgrade pip
         pip install torch==1.9.0+cpu torchvision==0.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
         make install_dev
-    - name: Run Flake8
-      run: make flake8
-    - name: Run Tests
-      run: make test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,23 @@
+default_language_version:
+  python: python3
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
+  autoupdate_schedule: quarterly
+  # submodules: true
+
 repos:
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        args: [ --config=pyproject.toml ]
+        args: ["--config=pyproject.toml"]
+
   - repo: https://github.com/pycqa/flake8.git
     rev: 4.0.1
     hooks:
     - id: flake8
-      args: [ --config=.flake8 ]
-      additional_dependencies: [ flake8-docstrings==1.6.0 ]
+      args: ["--config=.flake8"]
+      additional_dependencies:
+        - "flake8-docstrings==1.6.0"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ table:
 table_timm:
 	.venv/bin/python misc/generate_table_timm.py
 
-precommit: .venv
+precommit: install_dev
 	.venv/bin/pre-commit run --all-files
 
 all: precommit test

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,7 @@ table:
 table_timm:
 	.venv/bin/python misc/generate_table_timm.py
 
-black: .venv
-	.venv/bin/black ./segmentation_models_pytorch --config=pyproject.toml --check
+precommit: .venv
+	.venv/bin/pre-commit run --all-files
 
-flake8: .venv
-	.venv/bin/flake8 ./segmentation_models_pytorch --config=.flake8
-
-all: black flake8 test
+all: precommit test

--- a/README.md
+++ b/README.md
@@ -475,10 +475,10 @@ $ pip install git+https://github.com/qubvel/segmentation_models.pytorch
 make install_dev  # create .venv, install SMP in dev mode
 ```
 
-#### Run tests and code checks  
+#### Run tests and code checks
 
 ```bash
-make all          # run flake8, black, tests
+make all          # run precommit, tests
 ```
 
 #### Update table with encoders  

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,6 @@ EXTRAS = {
         "pytest",
         "mock",
         "pre-commit",
-        "black ==22.3.0",
-        "flake8 ==4.0.1",
-        "flake8-docstrings ==1.6.0",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ EXTRAS = {
         "pytest",
         "mock",
         "pre-commit",
-        "black==22.3.0",
-        "flake8==4.0.1",
-        "flake8-docstrings==1.6.0",
+        "black ==22.3.0",
+        "flake8 ==4.0.1",
+        "flake8-docstrings ==1.6.0",
     ],
 }
 


### PR DESCRIPTION
Calling pre-commit, which is defined already, instead of `flake8` and `black` separately
Also, I would highly recommend installing [pre-commit bot](https://github.com/marketplace/pre-commit-ci), which would also update a PR with fixable on the fly within PR

cc: @qubvel