### PR TITLE
In datasets/oxford_pet.py. Image.LINEAR >> Image.BILINEAR

### DIFF
--- a/segmentation_models_pytorch/datasets/oxford_pet.py
+++ b/segmentation_models_pytorch/datasets/oxford_pet.py
@@ -87,7 +87,7 @@ class SimpleOxfordPetDataset(OxfordPetDataset):
         sample = super().__getitem__(*args, **kwargs)
 
         # resize images
-        image = np.array(Image.fromarray(sample["image"]).resize((256, 256), Image.LINEAR))
+        image = np.array(Image.fromarray(sample["image"]).resize((256, 256), Image.BILINEAR))
         mask = np.array(Image.fromarray(sample["mask"]).resize((256, 256), Image.NEAREST))
         trimap = np.array(Image.fromarray(sample["trimap"]).resize((256, 256), Image.NEAREST))
 


### PR DESCRIPTION
The latest version of Pillow does not support Image. LINEAR. A similar option that we can use is Image.BILINEAR.

Reff:
[PIL.Image.LINEAR no longer exists #5010](https://github.com/facebookresearch/detectron2/issues/5010)