### PR TITLE
Replaced `view` with `replace` to prevent errors on non-contiguous tensors

### DIFF
--- a/segmentation_models_pytorch/losses/dice.py
+++ b/segmentation_models_pytorch/losses/dice.py
@@ -73,8 +73,8 @@ class DiceLoss(_Loss):
         dims = (0, 2)
 
         if self.mode == BINARY_MODE:
-            y_true = y_true.view(bs, 1, -1)
-            y_pred = y_pred.view(bs, 1, -1)
+            y_true = y_true.reshape(bs, 1, -1)
+            y_pred = y_pred.reshape(bs, 1, -1)
 
             if self.ignore_index is not None:
                 mask = y_true != self.ignore_index
@@ -82,8 +82,8 @@ class DiceLoss(_Loss):
                 y_true = y_true * mask
 
         if self.mode == MULTICLASS_MODE:
-            y_true = y_true.view(bs, -1)
-            y_pred = y_pred.view(bs, num_classes, -1)
+            y_true = y_true.reshape(bs, -1)
+            y_pred = y_pred.reshape(bs, num_classes, -1)
 
             if self.ignore_index is not None:
                 mask = y_true != self.ignore_index
@@ -98,8 +98,8 @@ class DiceLoss(_Loss):
                 y_true = y_true.permute(0, 2, 1)  # N, C, H*W
 
         if self.mode == MULTILABEL_MODE:
-            y_true = y_true.view(bs, num_classes, -1)
-            y_pred = y_pred.view(bs, num_classes, -1)
+            y_true = y_true.reshape(bs, num_classes, -1)
+            y_pred = y_pred.reshape(bs, num_classes, -1)
 
             if self.ignore_index is not None:
                 mask = y_true != self.ignore_index

--- a/segmentation_models_pytorch/losses/focal.py
+++ b/segmentation_models_pytorch/losses/focal.py
@@ -57,8 +57,8 @@ class FocalLoss(_Loss):
 
     def forward(self, y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
         if self.mode in {BINARY_MODE, MULTILABEL_MODE}:
-            y_true = y_true.view(-1)
-            y_pred = y_pred.view(-1)
+            y_true = y_true.reshape(-1)
+            y_pred = y_pred.reshape(-1)
 
             if self.ignore_index is not None:
                 # Filter predictions with ignore label from loss computation

--- a/segmentation_models_pytorch/losses/jaccard.py
+++ b/segmentation_models_pytorch/losses/jaccard.py
@@ -73,8 +73,8 @@ class JaccardLoss(_Loss):
         dims = (0, 2)
 
         if self.mode == BINARY_MODE:
-            y_true = y_true.view(bs, 1, -1)
-            y_pred = y_pred.view(bs, 1, -1)
+            y_true = y_true.reshape(bs, 1, -1)
+            y_pred = y_pred.reshape(bs, 1, -1)
 
             if self.ignore_index is not None:
                 mask = y_true != self.ignore_index
@@ -82,8 +82,8 @@ class JaccardLoss(_Loss):
                 y_true = y_true * mask
 
         if self.mode == MULTICLASS_MODE:
-            y_true = y_true.view(bs, -1)
-            y_pred = y_pred.view(bs, num_classes, -1)
+            y_true = y_true.reshape(bs, -1)
+            y_pred = y_pred.reshape(bs, num_classes, -1)
 
             if self.ignore_index is not None:
                 mask = y_true != self.ignore_index
@@ -98,8 +98,8 @@ class JaccardLoss(_Loss):
                 y_true = y_true.permute(0, 2, 1)  # N, C, H*W
 
         if self.mode == MULTILABEL_MODE:
-            y_true = y_true.view(bs, num_classes, -1)
-            y_pred = y_pred.view(bs, num_classes, -1)
+            y_true = y_true.reshape(bs, num_classes, -1)
+            y_pred = y_pred.reshape(bs, num_classes, -1)
 
             if self.ignore_index is not None:
                 mask = y_true != self.ignore_index

--- a/segmentation_models_pytorch/losses/lovasz.py
+++ b/segmentation_models_pytorch/losses/lovasz.py
@@ -77,8 +77,8 @@ def _flatten_binary_scores(scores, labels, ignore=None):
     """Flattens predictions in the batch (binary case)
     Remove labels equal to 'ignore'
     """
-    scores = scores.view(-1)
-    labels = labels.view(-1)
+    scores = scores.reshape(-1)
+    labels = labels.reshape(-1)
     if ignore is None:
         return scores, labels
     valid = labels != ignore
@@ -151,13 +151,13 @@ def _flatten_probas(probas, labels, ignore=None):
     if probas.dim() == 3:
         # assumes output of a sigmoid layer
         B, H, W = probas.size()
-        probas = probas.view(B, 1, H, W)
+        probas = probas.reshape(B, 1, H, W)
 
     C = probas.size(1)
     probas = torch.movedim(probas, 1, -1)  # [B, C, Di, Dj, ...] -> [B, Di, Dj, ..., C]
-    probas = probas.contiguous().view(-1, C)  # [P, C]
+    probas = probas.reshape(-1, C)  # [P, C]
 
-    labels = labels.view(-1)
+    labels = labels.reshape(-1)
     if ignore is None:
         return probas, labels
     valid = labels != ignore

--- a/segmentation_models_pytorch/losses/mcc.py
+++ b/segmentation_models_pytorch/losses/mcc.py
@@ -29,8 +29,8 @@ class MCCLoss(_Loss):
 
         bs = y_true.shape[0]
 
-        y_true = y_true.view(bs, 1, -1)
-        y_pred = y_pred.view(bs, 1, -1)
+        y_true = y_true.reshape(bs, 1, -1)
+        y_pred = y_pred.reshape(bs, 1, -1)
 
         tp = torch.sum(torch.mul(y_pred, y_true)) + self.eps
         tn = torch.sum(torch.mul((1 - y_pred), (1 - y_true))) + self.eps


### PR DESCRIPTION
Fixes #1163 (error if model predictions tensor is not contiguous)

