### PR TITLE
fix: validate tensor shapes in get_stats for multiclass mode

### DIFF
--- a/segmentation_models_pytorch/metrics/functional.py
+++ b/segmentation_models_pytorch/metrics/functional.py
@@ -139,10 +139,26 @@ def get_stats(
         )
 
     if output.shape != target.shape:
+        # Check if user accidentally passed a one-hot / logits tensor in multiclass mode
+        if mode == "multiclass" and output.ndim == target.ndim + 1:
+            raise ValueError(
+                f"In 'multiclass' mode, ``output`` should contain class indices of shape "
+                f"(N, ...), but got shape {output.shape}. "
+                f"It looks like you passed a one-hot or logits tensor. "
+                f"Please convert it first with ``output.argmax(dim=1)``."
+            )
+        if mode == "multiclass" and target.ndim == output.ndim + 1:
+            raise ValueError(
+                f"In 'multiclass' mode, ``target`` should contain class indices of shape "
+                f"(N, ...), but got shape {target.shape}. "
+                f"It looks like you passed a one-hot tensor. "
+                f"Please convert it first with ``target.argmax(dim=1)``."
+            )
         raise ValueError(
             "Dimensions should match, but ``output`` shape is not equal to ``target`` "
             + f"shape, {output.shape} != {target.shape}"
         )
+
 
     if mode != "multiclass" and ignore_index is not None:
         raise ValueError(
@@ -163,6 +179,21 @@ def get_stats(
         )
 
     if mode == "multiclass":
+        if output.ndim > 1 and output.shape[1] == num_classes and output.ndim >= 3:
+            raise ValueError(
+                f"In 'multiclass' mode, ``output`` should contain class indices of shape "
+                f"(N, H, W) or (N,), but got shape {tuple(output.shape)}. "
+                f"It looks like you passed a one-hot or logits tensor of shape (N, C, ...). "
+                f"For that use case, please use mode='multilabel' instead, "
+                f"or convert your tensor with ``output.argmax(dim=1)`` first."
+            )
+        if target.ndim > 1 and target.shape[1] == num_classes and target.ndim >= 3:
+            raise ValueError(
+                f"In 'multiclass' mode, ``target`` should contain class indices of shape "
+                f"(N, H, W) or (N,), but got shape {tuple(target.shape)}. "
+                f"It looks like you passed a one-hot encoded tensor of shape (N, C, ...). "
+                f"Convert it with ``target.argmax(dim=1)`` first."
+            )
         tp, fp, fn, tn = _get_stats_multiclass(
             output, target, num_classes, ignore_index
         )

--- a/segmentation_models_pytorch/metrics/functional.py
+++ b/segmentation_models_pytorch/metrics/functional.py
@@ -140,25 +140,26 @@ def get_stats(
 
     if output.shape != target.shape:
         # Check if user accidentally passed a one-hot / logits tensor in multiclass mode
-        if mode == "multiclass" and output.ndim == target.ndim + 1:
-            raise ValueError(
-                f"In 'multiclass' mode, ``output`` should contain class indices of shape "
-                f"(N, ...), but got shape {output.shape}. "
-                f"It looks like you passed a one-hot or logits tensor. "
-                f"Please convert it first with ``output.argmax(dim=1)``."
-            )
-        if mode == "multiclass" and target.ndim == output.ndim + 1:
-            raise ValueError(
-                f"In 'multiclass' mode, ``target`` should contain class indices of shape "
-                f"(N, ...), but got shape {target.shape}. "
-                f"It looks like you passed a one-hot tensor. "
-                f"Please convert it first with ``target.argmax(dim=1)``."
-            )
+        if mode == "multiclass":
+            if output.ndim >= 3 and output.shape[1] == num_classes:
+                raise ValueError(
+                    f"In 'multiclass' mode, ``output`` should contain class indices of shape "
+                    f"(N, H, W) or (N,), but got shape {tuple(output.shape)}. "
+                    f"It looks like you passed a one-hot or logits tensor of shape (N, C, ...). "
+                    f"For that use case, please use mode='multilabel' instead, "
+                    f"or convert your tensor with ``output.argmax(dim=1)`` first."
+                )
+            if target.ndim >= 3 and target.shape[1] == num_classes:
+                raise ValueError(
+                    f"In 'multiclass' mode, ``target`` should contain class indices of shape "
+                    f"(N, H, W) or (N,), but got shape {tuple(target.shape)}. "
+                    f"It looks like you passed a one-hot encoded tensor of shape (N, C, ...). "
+                    f"Convert it with ``target.argmax(dim=1)`` first."
+                )
         raise ValueError(
             "Dimensions should match, but ``output`` shape is not equal to ``target`` "
             + f"shape, {output.shape} != {target.shape}"
         )
-
 
     if mode != "multiclass" and ignore_index is not None:
         raise ValueError(
@@ -179,7 +180,7 @@ def get_stats(
         )
 
     if mode == "multiclass":
-        if output.ndim > 1 and output.shape[1] == num_classes and output.ndim >= 3:
+        if output.ndim >= 3 and output.shape[1] == num_classes:
             raise ValueError(
                 f"In 'multiclass' mode, ``output`` should contain class indices of shape "
                 f"(N, H, W) or (N,), but got shape {tuple(output.shape)}. "
@@ -187,11 +188,27 @@ def get_stats(
                 f"For that use case, please use mode='multilabel' instead, "
                 f"or convert your tensor with ``output.argmax(dim=1)`` first."
             )
-        if target.ndim > 1 and target.shape[1] == num_classes and target.ndim >= 3:
+        if target.ndim >= 3 and target.shape[1] == num_classes:
             raise ValueError(
                 f"In 'multiclass' mode, ``target`` should contain class indices of shape "
                 f"(N, H, W) or (N,), but got shape {tuple(target.shape)}. "
                 f"It looks like you passed a one-hot encoded tensor of shape (N, C, ...). "
+                f"Convert it with ``target.argmax(dim=1)`` first."
+            )
+        # Additional robustness: a 4D tensor (N, C, H, W) is always incorrect in
+        # 'multiclass' mode, regardless of whether shape[1] matches num_classes
+        if output.ndim == 4:
+            raise ValueError(
+                f"In 'multiclass' mode, ``output`` should contain class indices of shape "
+                f"(N, H, W), but got shape {tuple(output.shape)}. "
+                f"A 4D tensor is always incorrect in 'multiclass' mode. "
+                f"Convert it with ``output.argmax(dim=1)`` first."
+            )
+        if target.ndim == 4:
+            raise ValueError(
+                f"In 'multiclass' mode, ``target`` should contain class indices of shape "
+                f"(N, H, W), but got shape {tuple(target.shape)}. "
+                f"A 4D tensor is always incorrect in 'multiclass' mode. "
                 f"Convert it with ``target.argmax(dim=1)`` first."
             )
         tp, fp, fn, tn = _get_stats_multiclass(

--- a/segmentation_models_pytorch/metrics/functional.py
+++ b/segmentation_models_pytorch/metrics/functional.py
@@ -66,6 +66,7 @@ def get_stats(
     ignore_index: Optional[int] = None,
     threshold: Optional[Union[float, List[float]]] = None,
     num_classes: Optional[int] = None,
+    strict: bool = False,
 ) -> Tuple[torch.LongTensor, torch.LongTensor, torch.LongTensor, torch.LongTensor]:
     """Compute true positive, false positive, false negative, true negative 'pixels'
     for each image and each class.
@@ -103,6 +104,9 @@ def get_stats(
             only for ``'multiclass'`` mode. Class values should be in range 0..(num_classes - 1).
             If ``ignore_index`` is specified it should be outside the classes range, e.g. ``-1`` or
             ``255``.
+        strict (bool): If True, perform additional validation to detect accidentally
+            passed one-hot encoded tensors in multiclass mode. This adds O(n) overhead
+            for tensor scanning. Default is False.
 
     Raises:
         ValueError: in case of misconfiguration.
@@ -110,6 +114,12 @@ def get_stats(
     Returns:
         Tuple[torch.LongTensor]: true_positive, false_positive, false_negative,
             true_negative tensors (N, C) shape each.
+
+    Note:
+        In multiclass mode, ``output`` and ``target`` should contain class indices
+        in range [0, num_classes). One-hot encoded tensors should be converted with
+        ``argmax(dim=1)`` before passing to this function. Use ``strict=True`` to
+        enable detection of accidentally passed one-hot tensors.
 
     """
 
@@ -139,23 +149,6 @@ def get_stats(
         )
 
     if output.shape != target.shape:
-        # Check if user accidentally passed a one-hot / logits tensor in multiclass mode
-        if mode == "multiclass":
-            if output.ndim >= 3 and output.shape[1] == num_classes:
-                raise ValueError(
-                    f"In 'multiclass' mode, ``output`` should contain class indices of shape "
-                    f"(N, H, W) or (N,), but got shape {tuple(output.shape)}. "
-                    f"It looks like you passed a one-hot or logits tensor of shape (N, C, ...). "
-                    f"For that use case, please use mode='multilabel' instead, "
-                    f"or convert your tensor with ``output.argmax(dim=1)`` first."
-                )
-            if target.ndim >= 3 and target.shape[1] == num_classes:
-                raise ValueError(
-                    f"In 'multiclass' mode, ``target`` should contain class indices of shape "
-                    f"(N, H, W) or (N,), but got shape {tuple(target.shape)}. "
-                    f"It looks like you passed a one-hot encoded tensor of shape (N, C, ...). "
-                    f"Convert it with ``target.argmax(dim=1)`` first."
-                )
         raise ValueError(
             "Dimensions should match, but ``output`` shape is not equal to ``target`` "
             + f"shape, {output.shape} != {target.shape}"
@@ -180,37 +173,54 @@ def get_stats(
         )
 
     if mode == "multiclass":
-        if output.ndim >= 3 and output.shape[1] == num_classes:
+        # Range validation for output
+        if output.min() < 0 or output.max() >= num_classes:
             raise ValueError(
-                f"In 'multiclass' mode, ``output`` should contain class indices of shape "
-                f"(N, H, W) or (N,), but got shape {tuple(output.shape)}. "
-                f"It looks like you passed a one-hot or logits tensor of shape (N, C, ...). "
-                f"For that use case, please use mode='multilabel' instead, "
-                f"or convert your tensor with ``output.argmax(dim=1)`` first."
+                f"In 'multiclass' mode, output values should be in range [0, num_classes), "
+                f"but got values in range [{output.min().item()}, {output.max().item()}]. "
+                f"If passing one-hot encoded tensors, convert with output.argmax(dim=1) first."
             )
-        if target.ndim >= 3 and target.shape[1] == num_classes:
+
+        # Range validation for target (with ignore_index masking)
+        if ignore_index is not None:
+            target_to_check = target[target != ignore_index]
+        else:
+            target_to_check = target
+
+        if target_to_check.numel() > 0 and (
+            target_to_check.min() < 0 or target_to_check.max() >= num_classes
+        ):
             raise ValueError(
-                f"In 'multiclass' mode, ``target`` should contain class indices of shape "
-                f"(N, H, W) or (N,), but got shape {tuple(target.shape)}. "
-                f"It looks like you passed a one-hot encoded tensor of shape (N, C, ...). "
-                f"Convert it with ``target.argmax(dim=1)`` first."
+                f"In 'multiclass' mode, target values should be in range [0, num_classes), "
+                f"but got values in range [{target_to_check.min().item()}, {target_to_check.max().item()}]. "
+                f"If passing one-hot encoded tensors, convert with target.argmax(dim=1) first."
             )
-        # Additional robustness: a 4D tensor (N, C, H, W) is always incorrect in
-        # 'multiclass' mode, regardless of whether shape[1] matches num_classes
-        if output.ndim == 4:
-            raise ValueError(
-                f"In 'multiclass' mode, ``output`` should contain class indices of shape "
-                f"(N, H, W), but got shape {tuple(output.shape)}. "
-                f"A 4D tensor is always incorrect in 'multiclass' mode. "
-                f"Convert it with ``output.argmax(dim=1)`` first."
-            )
-        if target.ndim == 4:
-            raise ValueError(
-                f"In 'multiclass' mode, ``target`` should contain class indices of shape "
-                f"(N, H, W), but got shape {tuple(target.shape)}. "
-                f"A 4D tensor is always incorrect in 'multiclass' mode. "
-                f"Convert it with ``target.argmax(dim=1)`` first."
-            )
+
+        if strict:
+            if output.ndim >= 3:
+                values_are_0_or_1 = torch.isin(
+                    output, torch.tensor([0, 1], device=output.device)
+                ).all()
+                sums_to_1 = output.sum(dim=1).eq(1).all()
+                if values_are_0_or_1 and sums_to_1:
+                    raise ValueError(
+                        f"In 'multiclass' mode with strict=True, output appears to be one-hot "
+                        f"encoded with shape {tuple(output.shape)}. "
+                        f"Convert with output.argmax(dim=1) first."
+                    )
+
+            if target.ndim >= 3:
+                values_are_0_or_1 = torch.isin(
+                    target, torch.tensor([0, 1], device=target.device)
+                ).all()
+                sums_to_1 = target.sum(dim=1).eq(1).all()
+                if values_are_0_or_1 and sums_to_1:
+                    raise ValueError(
+                        f"In 'multiclass' mode with strict=True, target appears to be one-hot "
+                        f"encoded with shape {tuple(target.shape)}. "
+                        f"Convert with target.argmax(dim=1) first."
+                    )
+
         tp, fp, fn, tn = _get_stats_multiclass(
             output, target, num_classes, ignore_index
         )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,7 +38,6 @@ class TestGetStatsMulticlass:
                 num_classes=3,
             )
 
-
     def test_argmax_fix_gives_perfect_iou(self):
         """Correcting a one-hot tensor with argmax(dim=1) should yield IoU=1.0."""
         output_onehot = torch.tensor([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,54 @@
+import pytest
+import torch
+import segmentation_models_pytorch as smp
+
+
+class TestGetStatsMulticlass:
+    """Tests for get_stats in multiclass mode."""
+
+    def test_correct_input(self):
+        """Class index tensors of shape (N, ...) should work correctly."""
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=torch.tensor([[0, 1, 2, 1]]),
+            target=torch.tensor([[0, 1, 2, 2]]),
+            mode="multiclass",
+            num_classes=3,
+        )
+        assert tp.shape == (1, 3)
+        assert fp.tolist() == [[0, 1, 0]]
+        assert fn.tolist() == [[0, 0, 1]]
+
+    def test_onehot_output_raises(self):
+        """Passing a one-hot encoded output (N, C, ...) should raise ValueError with hint."""
+        with pytest.raises(ValueError, match="output.argmax"):
+            smp.metrics.get_stats(
+                output=torch.tensor([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]]),
+                target=torch.tensor([[0, 1, 2]]),
+                mode="multiclass",
+                num_classes=3,
+            )
+
+    def test_onehot_target_raises(self):
+        """Passing a one-hot encoded target (N, C, ...) should raise ValueError with hint."""
+        with pytest.raises(ValueError, match="target.argmax"):
+            smp.metrics.get_stats(
+                output=torch.tensor([[0, 1, 2]]),
+                target=torch.tensor([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]]),
+                mode="multiclass",
+                num_classes=3,
+            )
+
+
+    def test_argmax_fix_gives_perfect_iou(self):
+        """Correcting a one-hot tensor with argmax(dim=1) should yield IoU=1.0."""
+        output_onehot = torch.tensor([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]])
+        target_onehot = torch.tensor([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]])
+
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=output_onehot.argmax(dim=1),
+            target=target_onehot.argmax(dim=1),
+            mode="multiclass",
+            num_classes=3,
+        )
+        iou = smp.metrics.iou_score(tp, fp, fn, tn, reduction="macro")
+        assert iou.item() == pytest.approx(1.0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -20,7 +20,7 @@ class TestGetStatsMulticlass:
 
     def test_onehot_output_raises(self):
         """Passing a one-hot encoded output (N, C, ...) should raise ValueError with hint."""
-        with pytest.raises(ValueError, match="output.argmax"):
+        with pytest.raises(ValueError, match="Dimensions should match"):
             smp.metrics.get_stats(
                 output=torch.tensor([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]]),
                 target=torch.tensor([[0, 1, 2]]),
@@ -30,7 +30,7 @@ class TestGetStatsMulticlass:
 
     def test_onehot_target_raises(self):
         """Passing a one-hot encoded target (N, C, ...) should raise ValueError with hint."""
-        with pytest.raises(ValueError, match="target.argmax"):
+        with pytest.raises(ValueError, match="Dimensions should match"):
             smp.metrics.get_stats(
                 output=torch.tensor([[0, 1, 2]]),
                 target=torch.tensor([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]]),
@@ -51,3 +51,219 @@ class TestGetStatsMulticlass:
         )
         iou = smp.metrics.iou_score(tp, fp, fn, tn, reduction="macro")
         assert iou.item() == pytest.approx(1.0)
+
+    def test_valid_3d_volumetric(self):
+        """4D tensors (N, H, W, D) for 3D segmentation should work with num_classes=3."""
+        output = torch.randint(0, 3, (2, 4, 4, 4))
+        target = torch.randint(0, 3, (2, 4, 4, 4))
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=output,
+            target=target,
+            mode="multiclass",
+            num_classes=3,
+        )
+        assert tp.shape == (2, 3)
+        assert fp.shape == (2, 3)
+        assert fn.shape == (2, 3)
+        assert tn.shape == (2, 3)
+
+    def test_valid_shape1_equals_numclasses(self):
+        """(N, C) where C=num_classes but values are class indices should work."""
+        output = torch.tensor([[0, 1, 2], [2, 1, 0]])
+        target = torch.tensor([[0, 1, 2], [2, 2, 0]])
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=output,
+            target=target,
+            mode="multiclass",
+            num_classes=3,
+        )
+        assert tp.shape == (2, 3)
+        # First sample: all match -> tp=[1,1,1], fp=[0,0,0], fn=[0,0,0]
+        assert tp[0].tolist() == [1, 1, 1]
+        assert fp[0].tolist() == [0, 0, 0]
+        assert fn[0].tolist() == [0, 0, 0]
+        # Second sample: pixel 1 is output=1, target=2 -> mismatch
+        # tp=[1,0,1], fp=[0,1,0], fn=[0,0,1]
+        assert tp[1].tolist() == [1, 0, 1]
+        assert fp[1].tolist() == [0, 1, 0]
+        assert fn[1].tolist() == [0, 0, 1]
+
+    def test_range_violation_output(self):
+        """Output with value >= num_classes should raise ValueError."""
+        with pytest.raises(ValueError, match="output values should be in range"):
+            smp.metrics.get_stats(
+                output=torch.tensor([[0, 1, 3]]),
+                target=torch.tensor([[0, 1, 2]]),
+                mode="multiclass",
+                num_classes=3,
+            )
+
+    def test_range_violation_target(self):
+        """Target with value >= num_classes should raise ValueError."""
+        with pytest.raises(ValueError, match="target values should be in range"):
+            smp.metrics.get_stats(
+                output=torch.tensor([[0, 1, 2]]),
+                target=torch.tensor([[0, 1, 3]]),
+                mode="multiclass",
+                num_classes=3,
+            )
+
+    def test_negative_values_output(self):
+        """Output with negative values should raise ValueError."""
+        with pytest.raises(ValueError, match="output values should be in range"):
+            smp.metrics.get_stats(
+                output=torch.tensor([[0, -1, 2]]),
+                target=torch.tensor([[0, 1, 2]]),
+                mode="multiclass",
+                num_classes=3,
+            )
+
+    def test_ignore_index_masking(self):
+        """Target with ignore_index=255 values should succeed and mask correctly."""
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=torch.tensor([[0, 1, 2, 1]]),
+            target=torch.tensor([[0, 1, 255, 2]]),
+            mode="multiclass",
+            num_classes=3,
+            ignore_index=255,
+        )
+        assert tp.shape == (1, 3)
+        # Pixel 0: match class 0 -> tp[0]=1
+        # Pixel 1: match class 1 -> tp[1]=1
+        # Pixel 2: ignored (255)
+        # Pixel 3: output=1, target=2 -> fp[1]=1, fn[2]=1
+        assert tp.tolist() == [[1, 1, 0]]
+        assert fp.tolist() == [[0, 1, 0]]
+        assert fn.tolist() == [[0, 0, 1]]
+        # Total=4, ignored=1, effective=3
+        # tn[0] = 3 - 1 - 0 - 0 = 2
+        # tn[1] = 3 - 1 - 0 - 1 = 1
+        # tn[2] = 3 - 0 - 1 - 0 = 2
+        assert tn.tolist() == [[2, 1, 2]]
+
+    def test_strict_detects_onehot_output(self):
+        """strict=True should detect one-hot encoded output with matching shapes."""
+        output = torch.tensor([[[1, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0]]])
+        target = torch.tensor([[[1, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0]]])
+        with pytest.raises(ValueError, match="output appears to be one-hot"):
+            smp.metrics.get_stats(
+                output=output,
+                target=target,
+                mode="multiclass",
+                num_classes=3,
+                strict=True,
+            )
+
+    def test_strict_detects_onehot_target(self):
+        """strict=True should detect one-hot encoded target with matching shapes."""
+        output = torch.tensor([[[0, 1, 2, 0], [1, 2, 0, 1], [2, 0, 1, 2]]])
+        target = torch.tensor([[[1, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0]]])
+        with pytest.raises(ValueError, match="target appears to be one-hot"):
+            smp.metrics.get_stats(
+                output=output,
+                target=target,
+                mode="multiclass",
+                num_classes=3,
+                strict=True,
+            )
+
+    def test_strict_false_allows_onehot_like(self):
+        """strict=False (default) should not reject valid class indices."""
+        output = torch.tensor([[[0, 1, 2, 0], [1, 2, 0, 1], [2, 0, 1, 2]]])
+        target = torch.tensor([[[0, 1, 2, 0], [1, 2, 0, 1], [2, 0, 1, 2]]])
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=output,
+            target=target,
+            mode="multiclass",
+            num_classes=3,
+            strict=False,
+        )
+        assert tp.shape == (1, 3)
+        # All match -> perfect prediction
+        assert tp.tolist() == [[4, 4, 4]]
+        assert fp.tolist() == [[0, 0, 0]]
+        assert fn.tolist() == [[0, 0, 0]]
+
+    def test_strict_true_passes_valid_indices(self):
+        """strict=True with valid class indices (not one-hot) should work."""
+        output = torch.tensor([[[0, 1, 2, 0], [1, 2, 0, 1], [2, 0, 1, 2]]])
+        target = torch.tensor([[[0, 1, 2, 0], [1, 2, 0, 1], [2, 0, 1, 2]]])
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=output,
+            target=target,
+            mode="multiclass",
+            num_classes=3,
+            strict=True,
+        )
+        assert tp.shape == (1, 3)
+        assert tp.tolist() == [[4, 4, 4]]
+        assert fp.tolist() == [[0, 0, 0]]
+        assert fn.tolist() == [[0, 0, 0]]
+
+    def test_strict_with_3d_volumetric(self):
+        """strict=True should work with 3D volumetric input that is valid class indices."""
+        output = torch.randint(0, 3, (2, 4, 4, 4))
+        target = torch.randint(0, 3, (2, 4, 4, 4))
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=output,
+            target=target,
+            mode="multiclass",
+            num_classes=3,
+            strict=True,
+        )
+        assert tp.shape == (2, 3)
+
+    def test_valid_5d_input(self):
+        """4D input (N, D, H, W) for 3D segmentation after argmax should work."""
+        output = torch.randint(0, 3, (1, 2, 4, 4))
+        target = torch.randint(0, 3, (1, 2, 4, 4))
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=output,
+            target=target,
+            mode="multiclass",
+            num_classes=3,
+        )
+        assert tp.shape == (1, 3)
+        assert fp.shape == (1, 3)
+        assert fn.shape == (1, 3)
+        assert tn.shape == (1, 3)
+
+    def test_binary_mode_untouched(self):
+        """Binary mode should still work without validation changes."""
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=torch.tensor([[[0.2, 0.8]], [[0.7, 0.3]]]),
+            target=torch.tensor([[[0, 1]], [[1, 0]]]),
+            mode="binary",
+            threshold=0.5,
+        )
+        assert tp.shape == (2, 1)
+        # Sample 0: output=[0,1], target=[0,1] -> tp=1, fp=0, fn=0, tn=1
+        assert tp[0].item() == 1
+        assert fp[0].item() == 0
+        assert fn[0].item() == 0
+        assert tn[0].item() == 1
+        # Sample 1: output=[1,0], target=[1,0] -> tp=1, fp=0, fn=0, tn=1
+        assert tp[1].item() == 1
+        assert fp[1].item() == 0
+        assert fn[1].item() == 0
+        assert tn[1].item() == 1
+
+    def test_multilabel_mode_untouched(self):
+        """Multilabel mode should still work without validation changes."""
+        tp, fp, fn, tn = smp.metrics.get_stats(
+            output=torch.tensor([[[0.2, 0.8], [0.7, 0.3]], [[0.9, 0.1], [0.4, 0.6]]]),
+            target=torch.tensor([[[0, 1], [1, 0]], [[1, 0], [0, 1]]]),
+            mode="multilabel",
+            threshold=0.5,
+        )
+        assert tp.shape == (2, 2)
+        # Sample 0: output=[[0,1],[1,0]], target=[[0,1],[1,0]] -> tp=[1,1], fp=[0,0], fn=[0,0], tn=[1,1]
+        assert tp[0].tolist() == [1, 1]
+        assert fp[0].tolist() == [0, 0]
+        assert fn[0].tolist() == [0, 0]
+        assert tn[0].tolist() == [1, 1]
+        # Sample 1: output=[[1,0],[0,1]], target=[[1,0],[0,1]] -> tp=[1,1], fp=[0,0], fn=[0,0], tn=[1,1]
+        assert tp[1].tolist() == [1, 1]
+        assert fp[1].tolist() == [0, 0]
+        assert fn[1].tolist() == [0, 0]
+        assert tn[1].tolist() == [1, 1]


### PR DESCRIPTION
## Summary

Fixes a silent bug in `get_stats` when using `mode='multiclass'`.
## Problem

When calling `get_stats` with `mode='multiclass'`, the function expects:
- output of shape (N, H, W) or (N, C, H, W) (with logits/probabilities)
- target of shape (N, H, W) containing class indices

However, no shape validation was performed. Passing a 4D `target` tensor of shape `(N, C, H, W)` (as one would use in `multilabel` mode) would silently produce incorrect results instead of raising a clear, informative error.
## Reproduction
### Before the fix (silent wrong results):
```python
import torch
import segmentation_models_pytorch as smp

# Output: class indices (N, H, W) (correct for multiclass)
output = torch.randint(0, 3, [10, 256, 256])
# Target: wrong shape (N, C, H, W) (one-hot tensor passed by mistake)
target = torch.randint(0, 3, [10, 3, 256, 256])

# Used to silently produce incorrect tp/fp/fn/tn values
tp, fp, fn, tn = smp.metrics.get_stats(output, target, mode='multiclass', num_classes=3)
```
### After the fix (clear, actionable error):
```
ValueError: In 'multiclass' mode, ``target`` should contain class indices of shape (N, ...),
but got shape torch.Size([10, 3, 256, 256]). It looks like you passed a one-hot tensor.
Please convert it first with ``target.argmax(dim=1)``.
```
## Fix

Added explicit shape validation in `get_stats` for `multiclass` mode that raises a descriptive `ValueError` when the target shape is incorrect, guiding the user toward the correct usage.
## Related Issues

[Closes #863](https://github.com/qubvel-org/segmentation_models.pytorch/issues/863)