### PR TITLE
fix: don't re-download encoder weights when loading a pretrained model

### DIFF
--- a/segmentation_models_pytorch/base/hub_mixin.py
+++ b/segmentation_models_pytorch/base/hub_mixin.py
@@ -136,6 +136,11 @@ def from_pretrained(
         config = json.load(f)
     model_class_name = config.pop("_model_class")
 
+    # The checkpoint already stores the (trained) encoder weights, so there is no
+    # need to download the encoder's pretrained weights when reloading the model.
+    if "encoder_weights" in config:
+        kwargs.setdefault("encoder_weights", None)
+
     import segmentation_models_pytorch as smp
 
     model_class = getattr(smp, model_class_name)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,8 @@
+import os
+import json
 import torch
 import tempfile
+from unittest import mock
 import segmentation_models_pytorch as smp
 
 import pytest
@@ -34,3 +37,41 @@ def test_from_pretrained_with_mismatched_keys():
 
     assert len(mismatched_keys) == 2
     assert sorted(mismatched_keys) == sorted(expected_mismatched_keys)
+
+
+def test_from_pretrained_does_not_download_encoder_weights():
+    # encoder weights are stored in the checkpoint, so reloading a saved model
+    # should not re-download the encoder's pretrained weights (see issue #957)
+    model = smp.Unet("resnet18", encoder_weights=None, classes=1)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        model.save_pretrained(temp_dir)
+
+        # emulate a checkpoint trained from imagenet-pretrained encoder
+        config_path = os.path.join(temp_dir, "config.json")
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        config["encoder_weights"] = "imagenet"
+        with open(config_path, "w") as f:
+            json.dump(config, f)
+
+        with (
+            mock.patch(
+                "segmentation_models_pytorch.encoders.hf_hub_download",
+                side_effect=AssertionError("encoder weights should not be downloaded"),
+            ) as mock_hf_hub_download,
+            mock.patch(
+                "segmentation_models_pytorch.encoders.load_url",
+                side_effect=AssertionError("encoder weights should not be downloaded"),
+            ) as mock_load_url,
+        ):
+            restored_model = smp.from_pretrained(temp_dir)
+
+        mock_hf_hub_download.assert_not_called()
+        mock_load_url.assert_not_called()
+
+    # weights must still match the saved checkpoint
+    original_state_dict = model.state_dict()
+    restored_state_dict = restored_model.state_dict()
+    for key in original_state_dict:
+        assert torch.allclose(original_state_dict[key], restored_state_dict[key])


### PR DESCRIPTION
Fixes #957.

When you reload a model with `from_pretrained`, the encoder weights are already stored in the checkpoint, but the saved config still has `encoder_weights` set (e.g. `"imagenet"`), so smp went and re-downloaded the encoder's pretrained weights anyway. That makes loading fail offline / from a purely local path.

This skips the download when the config records `encoder_weights`, falling back to `None` so the checkpoint weights are used as-is. An explicit `encoder_weights=...` passed to `from_pretrained` still takes precedence via `setdefault`.

Added a test that asserts no encoder download happens on reload and that the restored weights match the saved model.