### PR TITLE
fix: clarify threshold error message

### DIFF
--- a/segmentation_models_pytorch/metrics/functional.py
+++ b/segmentation_models_pytorch/metrics/functional.py
@@ -120,7 +120,7 @@ def get_stats(
 
     if torch.is_floating_point(output) and threshold is None:
         raise ValueError(
-            f"Output should be one of the integer types if ``threshold`` is not None, got {output.dtype}."
+            f"Output should be one of the integer types if ``threshold`` is None, got {output.dtype}."
         )
 
     if torch.is_floating_point(output) and mode == "multiclass":

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,17 @@
+import pytest
+import torch
+
+from segmentation_models_pytorch.metrics import get_stats
+
+
+def test_get_stats_explains_float_output_requires_threshold() -> None:
+    output = torch.tensor([[[0.1, 0.8], [0.3, 0.7]]], dtype=torch.float32)
+    target = torch.tensor([[[0, 1], [0, 1]]], dtype=torch.long)
+
+    with pytest.raises(ValueError) as error:
+        get_stats(output, target, mode="binary", threshold=None)
+
+    assert str(error.value) == (
+        "Output should be one of the integer types if ``threshold`` is None, "
+        "got torch.float32."
+    )


### PR DESCRIPTION
## Summary
- Fix the get_stats error message for floating-point outputs when threshold is None.
- Add a regression test for the error message.

Closes #1167

## Testing
- uv run --python /opt/homebrew/bin/python3.12 --extra test pytest tests/test_metrics.py -q
- uv run ruff check segmentation_models_pytorch/metrics/functional.py tests/test_metrics.py
- uv run ruff format --check segmentation_models_pytorch/metrics/functional.py tests/test_metrics.py