### PR TITLE
Add FiLM conditioning module for smp.Unet (encoder hooks + decoder fork)

### DIFF
--- a/film/__init__.py
+++ b/film/__init__.py
@@ -1,0 +1,55 @@
+"""FiLM (Feature-wise Linear Modulation) conditioning for `smp.Unet`.
+
+Attaches a metadata-driven gamma/beta modulation to an existing
+`segmentation_models_pytorch.Unet`, at the encoder (via forward hooks),
+the decoder (via a forked `UnetDecoder`), or both — configurable per model,
+never by editing SMP's own source.
+
+Typical usage::
+
+    from film import MetadataSchema, FiLMConfig, build_film_unet
+
+    samples = [
+        {"sensor_gain": 400.0, "capture_mode": "indoor"},
+        {"sensor_gain": 900.0, "capture_mode": "outdoor"},
+    ]
+    schema = MetadataSchema.infer(samples)
+
+    model = build_film_unet(
+        schema,
+        film_config=FiLMConfig(target="both"),
+        encoder_name="resnet18",
+        encoder_weights="imagenet",
+        in_channels=1,
+        classes=2,
+    )
+
+    masks = model(images, metadata=[{"sensor_gain": 400.0, "capture_mode": "indoor"}])
+"""
+
+from .audit import AuditLog, collect_generators
+from .generator import FiLMGenerator, apply_film
+from .hooks import EncoderFiLM, MetaBox
+from .decoder_blocks import FiLMConv2dReLU, FiLMUnetDecoder, FiLMUnetDecoderBlock
+from .metadata_encoder import MetadataEncoder, UnknownCategoryError
+from .metadata_schema import FieldSpec, MetadataSchema
+from .wiring import FiLMConfig, FiLMUnet, build_film_unet
+
+__all__ = [
+    "FieldSpec",
+    "MetadataSchema",
+    "MetadataEncoder",
+    "UnknownCategoryError",
+    "FiLMGenerator",
+    "apply_film",
+    "EncoderFiLM",
+    "MetaBox",
+    "FiLMConv2dReLU",
+    "FiLMUnetDecoderBlock",
+    "FiLMUnetDecoder",
+    "FiLMConfig",
+    "FiLMUnet",
+    "build_film_unet",
+    "AuditLog",
+    "collect_generators",
+]

--- a/film/audit.py
+++ b/film/audit.py
@@ -1,0 +1,100 @@
+"""Auditing layer: every transformation FiLM applies has a hook into here —
+nothing modifies a tensor silently.
+
+Attaches (non-invasively, via forward hooks on ``FiLMGenerator`` instances —
+the same pattern as encoder-side conditioning itself) a recorder that keeps
+each generator's weight matrix and a rolling history of the (gamma, beta) it
+produced. Use ``AuditLog.summary()`` to check for the classic FiLM failure
+mode: gamma collapsing to ~1 and beta to ~0 well into training means the
+network has learned to ignore metadata.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+from .decoder_blocks import FiLMUnetDecoder
+from .generator import FiLMGenerator
+
+
+def collect_generators(film_unet: Any) -> Dict[str, FiLMGenerator]:
+    """Gather every ``FiLMGenerator`` in a ``FiLMUnet``, named by insertion
+    point, for handing to ``AuditLog.attach``.
+    """
+    generators: Dict[str, FiLMGenerator] = {}
+
+    encoder_film = getattr(film_unet, "encoder_film", None)
+    if encoder_film is not None:
+        for stage_idx, generator in zip(
+            encoder_film.stage_indices, encoder_film.generators
+        ):
+            generators[f"encoder.stage{stage_idx}"] = generator
+
+    decoder = film_unet.unet.decoder
+    if isinstance(decoder, FiLMUnetDecoder):
+        for block_idx, block in enumerate(decoder.blocks):
+            generators[f"decoder.block{block_idx}.conv1"] = block.conv1.film
+            generators[f"decoder.block{block_idx}.conv2"] = block.conv2.film
+
+    return generators
+
+
+class AuditLog:
+    def __init__(self, max_history: int = 1000):
+        self.max_history = max_history
+        self._history: Dict[str, List[Tuple[torch.Tensor, torch.Tensor]]] = {}
+        self._generators: Dict[str, FiLMGenerator] = {}
+        self._handles: List[Any] = []
+
+    def attach(self, named_generators: Dict[str, FiLMGenerator]) -> "AuditLog":
+        for name, generator in named_generators.items():
+            self._generators[name] = generator
+            self._history.setdefault(name, [])
+            handle = generator.register_forward_hook(self._make_hook(name))
+            self._handles.append(handle)
+        return self
+
+    def _make_hook(self, name: str):
+        def hook(module, inputs, output):
+            gamma, beta = output
+            history = self._history[name]
+            history.append((gamma.detach().cpu(), beta.detach().cpu()))
+            if len(history) > self.max_history:
+                del history[: len(history) - self.max_history]
+
+        return hook
+
+    def detach(self) -> None:
+        for handle in self._handles:
+            handle.remove()
+        self._handles = []
+
+    def weight_matrices(self) -> Dict[str, torch.Tensor]:
+        """The learned W per generator — heatmap directly against
+        (metadata field, channel) for interpretability, no forward pass needed.
+        """
+        return {
+            name: g.weight_matrix.detach().cpu() for name, g in self._generators.items()
+        }
+
+    def summary(self) -> Dict[str, Dict[str, float]]:
+        out: Dict[str, Dict[str, float]] = {}
+        for name, history in self._history.items():
+            if not history:
+                continue
+            gammas = torch.cat([g.flatten() for g, _ in history])
+            betas = torch.cat([b.flatten() for _, b in history])
+            out[name] = {
+                "gamma_mean": gammas.mean().item(),
+                "gamma_std": gammas.std().item(),
+                "beta_mean": betas.mean().item(),
+                "beta_std": betas.std().item(),
+                "n_samples": len(history),
+            }
+        return out
+
+    def reset(self) -> None:
+        for name in self._history:
+            self._history[name] = []

--- a/film/decoder_blocks.py
+++ b/film/decoder_blocks.py
@@ -1,0 +1,223 @@
+"""Decoder-side FiLM: a forked/subclassed copy of SMP's ``UnetDecoder``, with
+FiLM wired in after batchnorm and before activation — matching the placement
+used in the original FiLM paper. Lives entirely in ``film/``; SMP's own
+``decoders/unet/decoder.py`` is never imported for modification, only
+generic, unmodified helpers (``get_norm_layer``, ``Attention``,
+``UnetCenterBlock``) are reused as-is.
+
+The decoder has no pretrained weights of its own (only the encoder does), so
+swapping SMP's ``UnetDecoder`` for this FiLM-augmented equivalent is safe —
+it trains from scratch either way, exactly like the vendor decoder would.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from segmentation_models_pytorch.base.modules import Attention, get_norm_layer
+from segmentation_models_pytorch.decoders.unet.decoder import UnetCenterBlock
+
+from .generator import FiLMGenerator, apply_film
+from .hooks import MetaBox
+
+
+class FiLMConv2dReLU(nn.Module):
+    """Fork of ``segmentation_models_pytorch.base.modules.Conv2dReLU``, split
+    out of its ``nn.Sequential`` so FiLM can sit between norm and activation.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        meta_dim: int,
+        meta_box: MetaBox,
+        padding: int = 0,
+        stride: int = 1,
+        use_norm: Union[bool, str, Dict[str, Any]] = "batchnorm",
+    ):
+        super().__init__()
+        is_inplace_abn = use_norm == "inplace" or (
+            isinstance(use_norm, dict) and use_norm.get("type") == "inplace"
+        )
+        if is_inplace_abn:
+            raise NotImplementedError(
+                "use_norm='inplace' (InPlaceABN) fuses its own activation into the norm layer, "
+                "which leaves no post-norm/pre-activation seam for FiLM to attach to — "
+                "use 'batchnorm', 'identity', 'layernorm', or 'instancenorm' with FiLM decoder blocks."
+            )
+        self.meta_box = meta_box
+        norm = get_norm_layer(use_norm, out_channels)
+        is_identity = isinstance(norm, nn.Identity)
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            bias=is_identity,
+        )
+        self.norm = norm
+        self.film = FiLMGenerator(meta_dim, out_channels)
+        self.activation = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv(x)
+        x = self.norm(x)
+        m = self.meta_box.value
+        if m is None:
+            raise RuntimeError(
+                "FiLM decoder block ran with no metadata set — call FiLMUnet.forward(x, metadata), "
+                "not the wrapped Unet/decoder directly"
+            )
+        gamma, beta = self.film(m)
+        x = apply_film(x, gamma, beta)
+        x = self.activation(x)
+        return x
+
+
+class FiLMUnetDecoderBlock(nn.Module):
+    """Fork of ``UnetDecoderBlock``: identical structure, `conv1`/`conv2` are
+    ``FiLMConv2dReLU`` instead of ``Conv2dReLU`` — each is its own FiLM
+    insertion point, independently auditable (see audit.py).
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        skip_channels: int,
+        out_channels: int,
+        meta_dim: int,
+        meta_box: MetaBox,
+        use_norm: Union[bool, str, Dict[str, Any]] = "batchnorm",
+        attention_type: Optional[str] = None,
+        interpolation_mode: str = "nearest",
+    ):
+        super().__init__()
+        self.interpolation_mode = interpolation_mode
+        self.conv1 = FiLMConv2dReLU(
+            in_channels + skip_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            meta_dim=meta_dim,
+            meta_box=meta_box,
+            use_norm=use_norm,
+        )
+        self.attention1 = Attention(
+            attention_type, in_channels=in_channels + skip_channels
+        )
+        self.conv2 = FiLMConv2dReLU(
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            meta_dim=meta_dim,
+            meta_box=meta_box,
+            use_norm=use_norm,
+        )
+        self.attention2 = Attention(attention_type, in_channels=out_channels)
+
+    def forward(
+        self,
+        feature_map: torch.Tensor,
+        target_height: int,
+        target_width: int,
+        skip_connection: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        feature_map = F.interpolate(
+            feature_map,
+            size=(target_height, target_width),
+            mode=self.interpolation_mode,
+        )
+        if skip_connection is not None:
+            feature_map = torch.cat([feature_map, skip_connection], dim=1)
+            feature_map = self.attention1(feature_map)
+        feature_map = self.conv1(feature_map)
+        feature_map = self.conv2(feature_map)
+        feature_map = self.attention2(feature_map)
+        return feature_map
+
+
+class FiLMUnetDecoder(nn.Module):
+    """Fork of ``UnetDecoder``: same channel-plumbing logic, ``FiLMUnetDecoderBlock``
+    in place of ``UnetDecoderBlock``. ``add_center_block`` still reuses the
+    vendor ``UnetCenterBlock`` unmodified (vgg-style encoders only — no FiLM
+    insertion point there, out of scope for this pass).
+    """
+
+    def __init__(
+        self,
+        encoder_channels: Sequence[int],
+        decoder_channels: Sequence[int],
+        meta_dim: int,
+        meta_box: MetaBox,
+        n_blocks: int = 5,
+        use_norm: Union[bool, str, Dict[str, Any]] = "batchnorm",
+        attention_type: Optional[str] = None,
+        add_center_block: bool = False,
+        interpolation_mode: str = "nearest",
+    ):
+        super().__init__()
+
+        if n_blocks != len(decoder_channels):
+            raise ValueError(
+                "Model depth is {}, but you provide `decoder_channels` for {} blocks.".format(
+                    n_blocks, len(decoder_channels)
+                )
+            )
+
+        encoder_channels = encoder_channels[1:]
+        encoder_channels = encoder_channels[::-1]
+
+        head_channels = encoder_channels[0]
+        in_channels = [head_channels] + list(decoder_channels[:-1])
+        skip_channels = list(encoder_channels[1:]) + [0]
+        out_channels = decoder_channels
+
+        if add_center_block:
+            self.center = UnetCenterBlock(
+                head_channels, head_channels, use_norm=use_norm
+            )
+        else:
+            self.center = nn.Identity()
+
+        self.blocks = nn.ModuleList()
+        for block_in_channels, block_skip_channels, block_out_channels in zip(
+            in_channels, skip_channels, out_channels
+        ):
+            block = FiLMUnetDecoderBlock(
+                block_in_channels,
+                block_skip_channels,
+                block_out_channels,
+                meta_dim=meta_dim,
+                meta_box=meta_box,
+                use_norm=use_norm,
+                attention_type=attention_type,
+                interpolation_mode=interpolation_mode,
+            )
+            self.blocks.append(block)
+
+    def forward(self, features: List[torch.Tensor]) -> torch.Tensor:
+        spatial_shapes = [feature.shape[2:] for feature in features]
+        spatial_shapes = spatial_shapes[::-1]
+
+        features = features[1:]
+        features = features[::-1]
+
+        head = features[0]
+        skip_connections = features[1:]
+
+        x = self.center(head)
+
+        for i, decoder_block in enumerate(self.blocks):
+            height, width = spatial_shapes[i + 1]
+            skip_connection = skip_connections[i] if i < len(skip_connections) else None
+            x = decoder_block(x, height, width, skip_connection=skip_connection)
+
+        return x

--- a/film/generator.py
+++ b/film/generator.py
@@ -1,0 +1,54 @@
+"""The FiLM generator: a single tunable linear transform from metadata to
+per-channel (gamma, beta), and the broadcast/apply step.
+
+Deliberately a bare ``nn.Linear``, no nonlinearity — [gamma, beta] = W*m + b.
+Every entry of W is directly interpretable ("this metadata field pushes this
+channel's scale/shift by this much"). An MLP generator could capture
+cross-field interactions, but at the cost of exactly that auditability.
+Start linear; an MLP variant is a later ablation, not this one.
+
+Identity-initialized: at construction, W and b are zero, so every generator
+starts as gamma=1, beta=0 (a no-op) regardless of what metadata it's fed —
+FiLM begins as the identity transform relative to pretrained/baseline
+behavior and only deviates from it as training pushes W away from zero.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+
+
+class FiLMGenerator(nn.Module):
+    def __init__(self, meta_dim: int, channels: int):
+        super().__init__()
+        self.meta_dim = meta_dim
+        self.channels = channels
+        self.linear = nn.Linear(meta_dim, 2 * channels)
+        nn.init.zeros_(self.linear.weight)
+        nn.init.zeros_(self.linear.bias)
+
+    @property
+    def weight_matrix(self) -> torch.Tensor:
+        """The learned W, shape (2*channels, meta_dim) — first `channels` rows
+        drive gamma's deviation from 1, the rest drive beta. Read directly for
+        auditing (see audit.py), no need to run a forward pass.
+        """
+        return self.linear.weight
+
+    def forward(self, m: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        out = self.linear(m)
+        delta_gamma, beta = out.chunk(2, dim=-1)
+        gamma = 1.0 + delta_gamma
+        return gamma, beta
+
+
+def apply_film(
+    x: torch.Tensor, gamma: torch.Tensor, beta: torch.Tensor
+) -> torch.Tensor:
+    """Broadcast (B, C) gamma/beta onto a (B, C, H, W) feature map."""
+    gamma = gamma[:, :, None, None]
+    beta = beta[:, :, None, None]
+    return x * gamma + beta

--- a/film/hooks.py
+++ b/film/hooks.py
@@ -1,0 +1,82 @@
+"""Encoder-side FiLM: a forward hook on the encoder's feature-pyramid output.
+
+Backbone-agnostic by construction — every SMP encoder implements the same
+contract (`EncoderMixin`: ``forward(x) -> List[Tensor]``, ``out_channels``),
+so a single hook on the whole ``encoder`` module modulates any backbone's
+feature pyramid without knowing its internal layer names. This is what keeps
+pretrained encoder weights untouched: the hook runs *after* the encoder's own
+forward returns, rewriting the returned list — it never reaches into the
+encoder's own conv/BN stack, so nothing about weight loading changes.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+
+from .generator import FiLMGenerator, apply_film
+
+
+class MetaBox:
+    """One-slot mutable container carrying the current batch's encoded
+    metadata vector `m` from ``FiLMUnet.forward`` to the encoder hook and the
+    FiLM decoder, without changing either's call signature — both are
+    invoked positionally (``encoder(x)`` / ``decoder(features)``) by the
+    untouched vendor ``SegmentationModel.forward``, so there's no argument
+    slot to smuggle `m` through except a side channel like this one.
+
+    Not thread-safe across concurrent forward calls on the same model
+    instance — same limitation as any other stateful `nn.Module` buffer.
+    """
+
+    def __init__(self) -> None:
+        self.value: Optional[torch.Tensor] = None
+
+
+class EncoderFiLM(nn.Module):
+    """Holds one ``FiLMGenerator`` per conditioned encoder stage plus the
+    hook handle that applies them. Build and attach via ``EncoderFiLM(...).attach(encoder)``.
+    """
+
+    def __init__(
+        self,
+        out_channels: List[int],
+        meta_dim: int,
+        meta_box: MetaBox,
+        skip_input_stage: bool = True,
+    ):
+        super().__init__()
+        self.meta_box = meta_box
+        self.skip_input_stage = skip_input_stage
+        start = 1 if skip_input_stage else 0
+        self.stage_indices = list(range(start, len(out_channels)))
+        self.generators = nn.ModuleList(
+            [FiLMGenerator(meta_dim, out_channels[i]) for i in self.stage_indices]
+        )
+        self._handle = None
+
+    def _hook(
+        self, module: nn.Module, inputs, output: List[torch.Tensor]
+    ) -> List[torch.Tensor]:
+        m = self.meta_box.value
+        if m is None:
+            raise RuntimeError(
+                "encoder FiLM hook fired with no metadata set — call FiLMUnet.forward(x, metadata), "
+                "not the wrapped encoder directly"
+            )
+        features = list(output)
+        for generator, stage_idx in zip(self.generators, self.stage_indices):
+            gamma, beta = generator(m)
+            features[stage_idx] = apply_film(features[stage_idx], gamma, beta)
+        return features
+
+    def attach(self, encoder: nn.Module) -> "EncoderFiLM":
+        self._handle = encoder.register_forward_hook(self._hook)
+        return self
+
+    def detach(self) -> None:
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None

--- a/film/metadata_encoder.py
+++ b/film/metadata_encoder.py
@@ -1,0 +1,67 @@
+"""dict/JSON metadata -> fixed-order numeric vector `m`.
+
+The only encoding logic in the whole `film/` package — both the encoder-hook
+path and the decoder-fork path call through here, so a metadata field is
+encoded exactly one way no matter where it's used.
+
+Categorical fields are one-hot, not a learned embedding: the only learned
+transform between raw metadata and (gamma, beta) is the FiLMGenerator's
+single Linear layer (see generator.py). A learned embedding table ahead of
+it would add a second, opaque learned mapping and break the "read W directly
+off the weight matrix" auditability the design calls for.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+import torch
+
+from .metadata_schema import MetadataSchema
+
+
+class UnknownCategoryError(ValueError):
+    pass
+
+
+class MetadataEncoder:
+    def __init__(self, schema: MetadataSchema, unknown_category: str = "raise"):
+        if unknown_category not in ("raise", "zero"):
+            raise ValueError("unknown_category must be 'raise' or 'zero'")
+        self.schema = schema
+        self.unknown_category = unknown_category
+
+    def encode(self, meta: Dict[str, Any]) -> torch.Tensor:
+        chunks: List[float] = []
+        for f in self.schema.fields:
+            if f.name not in meta:
+                raise KeyError(
+                    f"metadata dict is missing required field {f.name!r} "
+                    f"(schema fields: {self.schema.field_names})"
+                )
+            value = meta[f.name]
+            if f.kind == "continuous":
+                v = float(value)
+                if f.mean is not None and f.std is not None:
+                    v = (v - f.mean) / f.std
+                chunks.append(v)
+            else:
+                one_hot = [0.0] * len(f.categories)
+                try:
+                    idx = f.categories.index(value)
+                    one_hot[idx] = 1.0
+                except ValueError:
+                    if self.unknown_category == "raise":
+                        raise UnknownCategoryError(
+                            f"value {value!r} for categorical field {f.name!r} is not in "
+                            f"the fitted vocabulary {f.categories} — refit the schema or "
+                            f"pass unknown_category='zero' to fall back to an all-zero encoding"
+                        )
+                    # unknown_category == "zero": leave the one-hot vector all-zero
+                chunks.extend(one_hot)
+        return torch.tensor(chunks, dtype=torch.float32)
+
+    def encode_batch(self, metas: Sequence[Dict[str, Any]]) -> torch.Tensor:
+        if not metas:
+            raise ValueError("encode_batch requires at least one metadata dict")
+        return torch.stack([self.encode(m) for m in metas], dim=0)

--- a/film/metadata_schema.py
+++ b/film/metadata_schema.py
@@ -1,0 +1,159 @@
+"""Metadata data contract — single source of truth for what a metadata dict
+looks like and how it maps onto a fixed-order numeric vector.
+
+Generic by design: this is not tied to any particular domain's field names.
+A field's encoding is picked from the Python type of the values observed for
+it (``int``/``float`` -> continuous, everything else -> categorical), so the
+same schema machinery works for sensor metadata, natural-image EXIF data,
+or anything else a caller wants to condition on.
+
+Imported by both the encoder-hook path (hooks.py) and the decoder-fork path
+(decoder_blocks.py) so field order/encoding is defined exactly once.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+
+@dataclass
+class FieldSpec:
+    """One metadata field's encoding rule.
+
+    kind="continuous": encoded as a single scalar, optionally standardized
+        with (mean, std) computed by ``MetadataSchema.fit``.
+    kind="categorical": encoded as a one-hot vector over ``categories``
+        (fixed at fit time — the vector length can't change after a
+        ``FiLMGenerator`` has been sized against it).
+    """
+
+    name: str
+    kind: str  # "continuous" | "categorical"
+    mean: Optional[float] = None
+    std: Optional[float] = None
+    categories: Optional[List[Any]] = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self.kind not in ("continuous", "categorical"):
+            raise ValueError(
+                f"FieldSpec.kind must be 'continuous' or 'categorical', got {self.kind!r}"
+            )
+
+    @property
+    def dim(self) -> int:
+        if self.kind == "continuous":
+            return 1
+        if self.categories is None:
+            raise ValueError(
+                f"categorical field {self.name!r} has no categories yet — call MetadataSchema.fit() first"
+            )
+        return len(self.categories)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "mean": self.mean,
+            "std": self.std,
+            "categories": self.categories,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "FieldSpec":
+        return cls(**d)
+
+
+def _infer_kind(value: Any) -> str:
+    # bool is a subclass of int in Python — treat it as categorical, not continuous
+    if isinstance(value, bool):
+        return "categorical"
+    if isinstance(value, (int, float)):
+        return "continuous"
+    return "categorical"
+
+
+class MetadataSchema:
+    """Fixed field order + encoding rules for dict-metadata -> vector `m`.
+
+    Build via ``MetadataSchema.infer(samples)`` to auto-detect field kinds
+    and fit normalization stats / category vocabularies from example data,
+    or construct explicitly with a list of ``FieldSpec`` for full control.
+    Field order is the order fields were first seen (or declared) — stable
+    across calls, since vector positions must not shift once a
+    ``FiLMGenerator`` has been sized against ``schema.dim``.
+    """
+
+    def __init__(self, fields: Optional[Sequence[FieldSpec]] = None):
+        self.fields: List[FieldSpec] = list(fields) if fields is not None else []
+        self._by_name: Dict[str, FieldSpec] = {f.name: f for f in self.fields}
+
+    @property
+    def field_names(self) -> List[str]:
+        return [f.name for f in self.fields]
+
+    @property
+    def dim(self) -> int:
+        return sum(f.dim for f in self.fields)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._by_name
+
+    def __getitem__(self, name: str) -> FieldSpec:
+        return self._by_name[name]
+
+    @classmethod
+    def infer(cls, samples: Sequence[Dict[str, Any]]) -> "MetadataSchema":
+        """Auto-detect field kinds from a batch of example metadata dicts,
+        then fit normalization stats / category vocabularies in one pass.
+        """
+        if not samples:
+            raise ValueError("need at least one metadata sample to infer a schema from")
+
+        names_in_order: List[str] = []
+        seen = set()
+        for sample in samples:
+            for name in sample.keys():
+                if name not in seen:
+                    seen.add(name)
+                    names_in_order.append(name)
+
+        schema = cls()
+        for name in names_in_order:
+            values = [s[name] for s in samples if name in s]
+            kind = _infer_kind(values[0])
+            schema.fields.append(FieldSpec(name=name, kind=kind))
+        schema._by_name = {f.name: f for f in schema.fields}
+        schema.fit(samples)
+        return schema
+
+    def fit(self, samples: Sequence[Dict[str, Any]]) -> "MetadataSchema":
+        """Compute (mean, std) for continuous fields and the category
+        vocabulary for categorical fields, from example data. Mutates and
+        returns self. Safe to call again to re-fit against new data.
+        """
+        for f in self.fields:
+            values = [s[f.name] for s in samples if f.name in s]
+            if not values:
+                continue
+            if f.kind == "continuous":
+                values = [float(v) for v in values]
+                n = len(values)
+                mean = sum(values) / n
+                variance = sum((v - mean) ** 2 for v in values) / n
+                f.mean = mean
+                f.std = variance**0.5 if variance > 0 else 1.0
+            else:
+                existing = list(f.categories) if f.categories else []
+                for v in values:
+                    if v not in existing:
+                        existing.append(v)
+                f.categories = existing
+        return self
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"fields": [f.to_dict() for f in self.fields]}
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "MetadataSchema":
+        return cls([FieldSpec.from_dict(fd) for fd in d["fields"]])

--- a/film/wiring.py
+++ b/film/wiring.py
@@ -1,0 +1,149 @@
+"""Attaches FiLM to a ``segmentation_models_pytorch.Unet`` per an
+encoder/decoder/both/none toggle — one wiring function, not four
+hand-maintained model variants.
+
+No vendor source file is edited: encoder-side FiLM is a forward hook
+(hooks.py) attached after the vendor ``Unet`` is fully constructed (so
+pretrained weights load exactly as ``smp.Unet(...)`` would, untouched);
+decoder-side FiLM swaps ``unet.decoder`` for the forked ``FiLMUnetDecoder``
+(decoder_blocks.py), built from the same channel config the vendor decoder
+would have received. Both insertion points share one ``MetadataEncoder``/
+``MetadataSchema`` and one ``MetaBox``, so metadata is encoded exactly once
+per forward call regardless of how many places condition on it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence, Union
+
+import torch
+import torch.nn as nn
+
+from segmentation_models_pytorch import Unet
+
+from .decoder_blocks import FiLMUnetDecoder
+from .hooks import EncoderFiLM, MetaBox
+from .metadata_encoder import MetadataEncoder
+from .metadata_schema import MetadataSchema
+
+FiLMTarget = str  # "none" | "encoder" | "decoder" | "both"
+_VALID_TARGETS = ("none", "encoder", "decoder", "both")
+
+
+@dataclass
+class FiLMConfig:
+    target: FiLMTarget = "both"
+    # encoder-side only: don't condition the raw-input passthrough feature (stage 0)
+    skip_input_stage: bool = True
+
+    def __post_init__(self) -> None:
+        if self.target not in _VALID_TARGETS:
+            raise ValueError(
+                f"FiLMConfig.target must be one of {_VALID_TARGETS}, got {self.target!r}"
+            )
+
+
+class FiLMUnet(nn.Module):
+    """Wraps a vendor ``Unet`` instance; adds a ``metadata`` argument to
+    ``forward``. Construct via ``build_film_unet(...)``, not directly —
+    that's what wires the encoder hook / decoder swap consistently with
+    ``config.target``.
+    """
+
+    def __init__(
+        self,
+        unet: Unet,
+        schema: MetadataSchema,
+        config: FiLMConfig,
+        meta_box: MetaBox,
+        encoder_film: Optional[EncoderFiLM] = None,
+    ):
+        super().__init__()
+        self.unet = unet
+        self.schema = schema
+        self.config = config
+        self.meta_box = meta_box
+        self.metadata_encoder = MetadataEncoder(schema)
+        # setting an nn.Module attribute registers it as a submodule (params
+        # visible via film_unet.parameters()/state_dict()); None is fine too,
+        # it just stays a plain attribute when there's no encoder-side FiLM.
+        self.encoder_film = encoder_film
+
+    @property
+    def uses_decoder_film(self) -> bool:
+        return isinstance(self.unet.decoder, FiLMUnetDecoder)
+
+    def forward(self, x: torch.Tensor, metadata: Sequence[Dict[str, Any]]):
+        m = self.metadata_encoder.encode_batch(metadata).to(x.device)
+        self.meta_box.value = m
+        try:
+            return self.unet(x)
+        finally:
+            self.meta_box.value = None
+
+
+def build_film_unet(
+    schema: MetadataSchema,
+    film_config: Optional[FiLMConfig] = None,
+    encoder_name: str = "resnet34",
+    encoder_depth: int = 5,
+    encoder_weights: Optional[str] = "imagenet",
+    decoder_use_norm: Union[bool, str, Dict[str, Any]] = "batchnorm",
+    decoder_channels: Sequence[int] = (256, 128, 64, 32, 16),
+    decoder_attention_type: Optional[str] = None,
+    decoder_interpolation: str = "nearest",
+    in_channels: int = 3,
+    classes: int = 1,
+    activation: Optional[Any] = None,
+    aux_params: Optional[dict] = None,
+    **encoder_kwargs: Any,
+) -> FiLMUnet:
+    """Build a ``smp.Unet`` exactly as ``smp.Unet(...)`` would — same
+    arguments, same pretrained-weight loading — then attach FiLM per
+    ``film_config.target`` without touching any vendor source file.
+    """
+    config = film_config or FiLMConfig()
+
+    unet = Unet(
+        encoder_name=encoder_name,
+        encoder_depth=encoder_depth,
+        encoder_weights=encoder_weights,
+        decoder_use_norm=decoder_use_norm,
+        decoder_channels=decoder_channels,
+        decoder_attention_type=decoder_attention_type,
+        decoder_interpolation=decoder_interpolation,
+        in_channels=in_channels,
+        classes=classes,
+        activation=activation,
+        aux_params=aux_params,
+        **encoder_kwargs,
+    )
+
+    meta_box = MetaBox()
+    encoder_film = None
+
+    if config.target in ("encoder", "both"):
+        encoder_film = EncoderFiLM(
+            out_channels=list(unet.encoder.out_channels),
+            meta_dim=schema.dim,
+            meta_box=meta_box,
+            skip_input_stage=config.skip_input_stage,
+        )
+        encoder_film.attach(unet.encoder)
+
+    if config.target in ("decoder", "both"):
+        add_center_block = encoder_name.startswith("vgg")
+        unet.decoder = FiLMUnetDecoder(
+            encoder_channels=unet.encoder.out_channels,
+            decoder_channels=decoder_channels,
+            meta_dim=schema.dim,
+            meta_box=meta_box,
+            n_blocks=encoder_depth,
+            use_norm=decoder_use_norm,
+            add_center_block=add_center_block,
+            attention_type=decoder_attention_type,
+            interpolation_mode=decoder_interpolation,
+        )
+
+    return FiLMUnet(unet, schema, config, meta_box, encoder_film=encoder_film)


### PR DESCRIPTION
Images generally come with metadata that could help a model's predictions if that information is injected into the network's filters. I've added an optional encoder/decoder conditioning mechanism that can automatically take a metadata dictionary and modulate the feature maps with it.