### PR TITLE
Harden legacy URL fallback: pass weights_only=True to load_url

### DIFF
--- a/segmentation_models_pytorch/encoders/__init__.py
+++ b/segmentation_models_pytorch/encoders/__init__.py
@@ -144,7 +144,7 @@ def get_encoder(name, in_channels=3, depth=5, weights=None, output_stride=32, **
                 )
                 warnings.warn(message, UserWarning)
                 url = pretrained_settings[name][weights]["url"]
-                state_dict = load_url(url, map_location="cpu")
+                state_dict = load_url(url, map_location="cpu", weights_only=True)
             else:
                 raise e
 


### PR DESCRIPTION
The legacy fallback in get_encoder() fetches encoder weights with:

    state_dict = load_url(url, map_location="cpu")

torch.hub.load_state_dict_from_url defaults to weights_only=False, so this performs a full pickle deserialisation of the downloaded .pth. Note that torch.load itself switched to weights_only=True in torch 2.6, but load_state_dict_from_url kept the old default, so callers do not inherit that hardening automatically.

The URLs used by this fallback (pretrained_settings in _legacy_pretrained_settings.py) are plain http://, so the bytes being unpickled are not authenticated in transit. check_hash also defaults to False, so the SHA256 prefix already present in each filename is not verified.

Passing weights_only=True restricts loading to tensors/plain data, which is all a state_dict needs here, and removes the arbitrary-code-execution surface.

Two follow-ups the maintainers may want, kept out of this PR to keep it minimal:

1. Switch the ~21 http:// entries in _legacy_pretrained_settings.py to https://. I verified https://data.lip6.fr/cadene/pretrainedmodels/ serves the full directory over TLS with every referenced file present, so this looks like a drop-in change.
2. Consider check_hash=True. I have deliberately not included it because I have not verified that every filename suffix is a genuine SHA256 prefix; if any are not, enabling it would break those downloads.

Happy to adjust or split this however you prefer.